### PR TITLE
Build KANAGAWA01 Daedalus foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ secrets/
 docs/
 ```
 
-See [docs/layout.md](docs/layout.md) for the responsibility split.
+See [docs/layout.md](docs/layout.md) for the responsibility split. See
+[docs/bootstrap-control-node.md](docs/bootstrap-control-node.md) for the first
+KANAGAWA01 control node bootstrap boundary and
+[docs/atlas-host.md](docs/atlas-host.md) for the Atlas host role.
 
 ## Installation
 
@@ -81,6 +84,11 @@ Production execution should go through `atlas run` or the shim so Atlas can
 provide the release runtime, host context, and JSONL run log. Direct local Python
 entrypoints are for development only.
 
+The first KANAGAWA01 control node, `kng01-mgmt-control-01`, is manually
+bootstrapped. Daedalus validates that host and can manage non-dangerous
+configuration, but it does not rebuild the active Atlas runtime there by
+default.
+
 ## CLI
 
 Basic shape:
@@ -102,7 +110,7 @@ Reachability:
 
 ```bash
 infra ping
-infra ping --site kanagawa01 --limit kng01-recursive-dns-01
+infra ping --site kanagawa01 --limit kng01-mgmt-recdns-01
 ```
 
 Dry-run validation:
@@ -110,21 +118,21 @@ Dry-run validation:
 ```bash
 infra check
 infra check --site kanagawa01 --playbook baseline
-infra check --site kanagawa01 --playbook baseline --limit kng01-recursive-dns-01
+infra check --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
 ```
 
 Diff preview:
 
 ```bash
 infra diff
-infra diff --site kanagawa01 --playbook baseline --limit kng01-recursive-dns-01
+infra diff --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
 ```
 
 Apply is the mutating action and requires explicit confirmation:
 
 ```bash
 infra apply --yes
-infra apply --yes --site kanagawa01 --playbook baseline --limit kng01-recursive-dns-01
+infra apply --yes --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
 ```
 
 `check`, `diff`, and `apply` support these limited Ansible pass-through options:
@@ -224,7 +232,7 @@ python -m pip install -e .
 infra sites
 infra playbooks
 infra inventory
-infra check --site kanagawa01 --playbook baseline --limit kng01-recursive-dns-01
+infra check --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
 ```
 
 For documentation-only changes, inspect the rendered Markdown and confirm that

--- a/ansible/playbooks/atlas.yml
+++ b/ansible/playbooks/atlas.yml
@@ -1,0 +1,8 @@
+---
+- name: Configure Atlas hosts
+  hosts: kanagawa01
+  gather_facts: true
+
+  roles:
+    - role: atlas_host
+      when: atlas_enabled | default(inventory_hostname == "kng01-mgmt-control-01")

--- a/ansible/playbooks/baseline.yml
+++ b/ansible/playbooks/baseline.yml
@@ -3,7 +3,5 @@
   hosts: kanagawa01
   gather_facts: true
 
-  tasks:
-    - name: Show target host
-      ansible.builtin.debug:
-        msg: "baseline target={{ inventory_hostname }} site={{ site_name | default('unknown') }}"
+  roles:
+    - role: baseline

--- a/ansible/playbooks/dns.yml
+++ b/ansible/playbooks/dns.yml
@@ -1,6 +1,6 @@
 ---
 - name: Configure DNS hosts
-  hosts: kng01-recursive-dns-01:kng01-recursive-dns-02
+  hosts: kng01-mgmt-recdns-01:kng01-mgmt-recdns-02
   gather_facts: true
 
   tasks:

--- a/ansible/roles/atlas_host/defaults/main.yml
+++ b/ansible/roles/atlas_host/defaults/main.yml
@@ -1,22 +1,16 @@
 ---
-site_name: kanagawa01
-site_short_name: kng01
-
-ansible_user: ops
-ansible_become: true
-
 atlas_home: /opt/atlas
 atlas_etc_dir: /etc/atlas
 atlas_var_dir: /var/lib/atlas
-atlas_tmp_dir: /opt/atlas/tmp
-atlas_python_build_cache_path: /var/lib/atlas/cache/python-build
-
-atlas_runtime_python_version: "3.12.3"
+atlas_tmp_dir: "{{ atlas_home }}/tmp"
+atlas_python_build_cache_path: "{{ atlas_var_dir }}/cache/python-build"
 
 atlas_cli_venv: /home/ops/.local/share/atlas-cli-venv
 atlas_cli_bin_dir: /home/ops/.local/bin
-atlas_cli_bin: /home/ops/.local/bin/atlas
+atlas_cli_bin: "{{ atlas_cli_bin_dir }}/atlas"
 atlas_cli_source: "git+https://github.com/alflag-org/atlas.git@master"
+
+atlas_runtime_python_version: "3.12.3"
 
 atlas_releases:
   daedalus:
@@ -25,3 +19,7 @@ atlas_releases:
 atlas_registries:
   daedalus:
     source: "git+https://github.com/alflag-org/daedalus.git#master"
+
+atlas_manage_runtime: false
+atlas_validate_runtime: true
+atlas_validate_shebangs: true

--- a/ansible/roles/atlas_host/tasks/cli.yml
+++ b/ansible/roles/atlas_host/tasks/cli.yml
@@ -1,0 +1,47 @@
+---
+- name: Create Atlas CLI directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: ops
+    group: ops
+    mode: "0755"
+  loop:
+    - "{{ atlas_cli_venv | dirname }}"
+    - "{{ atlas_cli_bin_dir }}"
+  become: true
+
+- name: Create Atlas CLI venv
+  ansible.builtin.command:
+    cmd: "python3 -m venv {{ atlas_cli_venv }}"
+    creates: "{{ atlas_cli_venv }}/bin/python"
+  become: true
+  become_user: ops
+
+- name: Upgrade pip in Atlas CLI venv
+  ansible.builtin.command:
+    cmd: "{{ atlas_cli_venv }}/bin/python -m pip install --upgrade pip"
+  environment:
+    TMPDIR: "{{ atlas_tmp_dir }}"
+  become: true
+  become_user: ops
+  changed_when: false
+
+- name: Install Atlas CLI
+  ansible.builtin.command:
+    cmd: "{{ atlas_cli_venv }}/bin/python -m pip install --upgrade {{ atlas_cli_source }}"
+  environment:
+    TMPDIR: "{{ atlas_tmp_dir }}"
+  become: true
+  become_user: ops
+  changed_when: true
+
+- name: Link atlas command
+  ansible.builtin.file:
+    src: "{{ atlas_cli_venv }}/bin/atlas"
+    dest: "{{ atlas_cli_bin }}"
+    state: link
+    force: "{{ ansible_check_mode }}"
+    owner: ops
+    group: ops
+  become: true

--- a/ansible/roles/atlas_host/tasks/config.yml
+++ b/ansible/roles/atlas_host/tasks/config.yml
@@ -1,0 +1,18 @@
+---
+- name: Render Atlas config.yml
+  ansible.builtin.template:
+    src: config.yml.j2
+    dest: "{{ atlas_etc_dir }}/config.yml"
+    owner: ops
+    group: ops
+    mode: "0644"
+  become: true
+
+- name: Render Atlas host.yml
+  ansible.builtin.template:
+    src: host.yml.j2
+    dest: "{{ atlas_etc_dir }}/host.yml"
+    owner: ops
+    group: ops
+    mode: "0644"
+  become: true

--- a/ansible/roles/atlas_host/tasks/directories.yml
+++ b/ansible/roles/atlas_host/tasks/directories.yml
@@ -1,0 +1,15 @@
+---
+- name: Create Atlas directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: ops
+    group: ops
+    mode: "0755"
+  loop:
+    - "{{ atlas_etc_dir }}"
+    - "{{ atlas_home }}"
+    - "{{ atlas_var_dir }}"
+    - "{{ atlas_tmp_dir }}"
+    - "{{ atlas_python_build_cache_path }}"
+  become: true

--- a/ansible/roles/atlas_host/tasks/env.yml
+++ b/ansible/roles/atlas_host/tasks/env.yml
@@ -1,0 +1,14 @@
+---
+- name: Ensure Atlas environment profile
+  ansible.builtin.blockinfile:
+    path: /home/ops/.profile
+    marker: "# {mark} ANSIBLE MANAGED ATLAS ENV"
+    create: true
+    owner: ops
+    group: ops
+    mode: "0644"
+    block: |
+      export PATH="$HOME/.local/bin:{{ atlas_home }}/bin:{{ atlas_home }}/shims:$PATH"
+      export TMPDIR="{{ atlas_tmp_dir }}"
+      export PYTHON_BUILD_CACHE_PATH="{{ atlas_python_build_cache_path }}"
+  become: true

--- a/ansible/roles/atlas_host/tasks/main.yml
+++ b/ansible/roles/atlas_host/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Install packages
+  ansible.builtin.import_tasks: packages.yml
+
+- name: Create directories
+  ansible.builtin.import_tasks: directories.yml
+
+- name: Install pyenv
+  ansible.builtin.import_tasks: pyenv.yml
+
+- name: Configure environment
+  ansible.builtin.import_tasks: env.yml
+
+- name: Render Atlas configuration
+  ansible.builtin.import_tasks: config.yml
+
+- name: Install Atlas CLI
+  ansible.builtin.import_tasks: cli.yml
+
+- name: Update Atlas scripts
+  ansible.builtin.import_tasks: scripts.yml
+
+- name: Manage Atlas runtime
+  ansible.builtin.import_tasks: runtime.yml
+
+- name: Validate Atlas host
+  ansible.builtin.import_tasks: validate.yml

--- a/ansible/roles/atlas_host/tasks/packages.yml
+++ b/ansible/roles/atlas_host/tasks/packages.yml
@@ -1,0 +1,32 @@
+---
+- name: Install Atlas host packages
+  ansible.builtin.apt:
+    name:
+      - git
+      - curl
+      - ca-certificates
+      - sudo
+      - openssh-client
+      - rsync
+      - python3
+      - python3-venv
+      - python3-pip
+      - build-essential
+      - make
+      - gcc
+      - libssl-dev
+      - zlib1g-dev
+      - libbz2-dev
+      - libreadline-dev
+      - libsqlite3-dev
+      - llvm
+      - libncurses-dev
+      - xz-utils
+      - tk-dev
+      - libxml2-dev
+      - libxmlsec1-dev
+      - libffi-dev
+      - liblzma-dev
+    state: present
+    update_cache: true
+  become: true

--- a/ansible/roles/atlas_host/tasks/pyenv.yml
+++ b/ansible/roles/atlas_host/tasks/pyenv.yml
@@ -1,0 +1,23 @@
+---
+- name: Install pyenv
+  ansible.builtin.git:
+    repo: https://github.com/pyenv/pyenv.git
+    dest: /home/ops/.pyenv
+    version: master
+    update: true
+  become: true
+  become_user: ops
+
+- name: Ensure pyenv shell profile
+  ansible.builtin.blockinfile:
+    path: /home/ops/.profile
+    marker: "# {mark} ANSIBLE MANAGED PYENV"
+    create: true
+    owner: ops
+    group: ops
+    mode: "0644"
+    block: |
+      export PYENV_ROOT="$HOME/.pyenv"
+      [[ -d "$PYENV_ROOT/bin" ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+      eval "$(pyenv init - bash)"
+  become: true

--- a/ansible/roles/atlas_host/tasks/runtime.yml
+++ b/ansible/roles/atlas_host/tasks/runtime.yml
@@ -1,0 +1,26 @@
+---
+- name: Install Atlas runtime
+  ansible.builtin.command:
+    cmd: "{{ atlas_cli_bin }} runtime install"
+  environment:
+    PATH: "/home/ops/.pyenv/bin:/home/ops/.local/bin:{{ atlas_home }}/bin:{{ atlas_home }}/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    PYENV_ROOT: "/home/ops/.pyenv"
+    TMPDIR: "{{ atlas_tmp_dir }}"
+    PYTHON_BUILD_CACHE_PATH: "{{ atlas_python_build_cache_path }}"
+  become: true
+  become_user: ops
+  changed_when: true
+  when: atlas_manage_runtime | bool
+
+- name: Work around stale shebang issue after runtime install
+  ansible.builtin.command:
+    cmd: >-
+      {{ atlas_home }}/runtime/python/envs/scripts/bin/python
+      -m pip install --force-reinstall
+      ansible-core>=2.18 fire>=0.7 PyYAML
+  environment:
+    TMPDIR: "{{ atlas_tmp_dir }}"
+  become: true
+  become_user: ops
+  changed_when: true
+  when: atlas_manage_runtime | bool

--- a/ansible/roles/atlas_host/tasks/scripts.yml
+++ b/ansible/roles/atlas_host/tasks/scripts.yml
@@ -1,0 +1,12 @@
+---
+- name: Update Atlas scripts releases
+  ansible.builtin.command:
+    cmd: "{{ atlas_cli_bin }} scripts update"
+  environment:
+    PATH: "/home/ops/.pyenv/bin:/home/ops/.local/bin:{{ atlas_home }}/bin:{{ atlas_home }}/shims:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    PYENV_ROOT: "/home/ops/.pyenv"
+    TMPDIR: "{{ atlas_tmp_dir }}"
+    PYTHON_BUILD_CACHE_PATH: "{{ atlas_python_build_cache_path }}"
+  become: true
+  become_user: ops
+  changed_when: true

--- a/ansible/roles/atlas_host/tasks/validate.yml
+++ b/ansible/roles/atlas_host/tasks/validate.yml
@@ -1,0 +1,48 @@
+---
+- name: Check Atlas status
+  ansible.builtin.command:
+    cmd: "{{ atlas_cli_bin }} status"
+  become: true
+  become_user: ops
+  check_mode: false
+  changed_when: false
+
+- name: Check Atlas runtime status
+  ansible.builtin.command:
+    cmd: "{{ atlas_cli_bin }} runtime status"
+  become: true
+  become_user: ops
+  check_mode: false
+  changed_when: false
+  when: atlas_validate_runtime | bool
+
+- name: Check daedalus command discovery
+  ansible.builtin.command:
+    cmd: "{{ atlas_cli_bin }} scripts list --verbose"
+  become: true
+  become_user: ops
+  check_mode: false
+  changed_when: false
+
+- name: Check ansible-inventory version
+  ansible.builtin.command:
+    cmd: "{{ atlas_home }}/runtime/python/envs/scripts/bin/ansible-inventory --version"
+  become: true
+  become_user: ops
+  check_mode: false
+  changed_when: false
+  when: atlas_validate_runtime | bool
+
+- name: Validate ansible-inventory shebang
+  ansible.builtin.shell: |
+    set -euo pipefail
+    test "$(head -1 {{ atlas_home }}/runtime/python/envs/scripts/bin/ansible-inventory)" = "#!{{ atlas_home }}/runtime/python/envs/scripts/bin/python"
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: ops
+  check_mode: false
+  changed_when: false
+  when:
+    - atlas_validate_runtime | bool
+    - atlas_validate_shebangs | bool

--- a/ansible/roles/atlas_host/templates/config.yml.j2
+++ b/ansible/roles/atlas_host/templates/config.yml.j2
@@ -1,0 +1,16 @@
+runtime:
+  python:
+    version: "{{ atlas_runtime_python_version }}"
+
+scripts:
+  releases:
+{% for name, release in atlas_releases.items() %}
+    {{ name }}:
+      source: {{ release.source }}
+{% endfor %}
+
+  registries:
+{% for name, registry in atlas_registries.items() %}
+    {{ name }}:
+      source: "{{ registry.source }}"
+{% endfor %}

--- a/ansible/roles/atlas_host/templates/host.yml.j2
+++ b/ansible/roles/atlas_host/templates/host.yml.j2
@@ -1,0 +1,10 @@
+{% set rendered_atlas_role = atlas_role | default('control' if inventory_hostname == 'kng01-mgmt-control-01' else 'host') %}
+name: {{ inventory_hostname }}
+site: {{ site_name }}
+zone: {{ network_zone | default('mgmt') }}
+role: {{ rendered_atlas_role }}
+environment: home
+runtime_kind: {{ atlas_runtime_kind | default('vm') }}
+tags:
+  - atlas
+  - {{ rendered_atlas_role }}

--- a/ansible/roles/baseline/defaults/main.yml
+++ b/ansible/roles/baseline/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+baseline_timezone_policy_enabled: false
+baseline_packages_policy_enabled: false

--- a/ansible/roles/baseline/tasks/main.yml
+++ b/ansible/roles/baseline/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Show baseline target
+  ansible.builtin.debug:
+    msg: "baseline target={{ inventory_hostname }} site={{ site_name | default('unknown') }}"
+
+- name: Confirm hostname fact is available
+  ansible.builtin.assert:
+    that:
+      - ansible_hostname is defined
+      - ansible_hostname | length > 0
+    quiet: true
+
+- name: Confirm Python fact gathering works
+  ansible.builtin.assert:
+    that:
+      - ansible_python_version is defined
+      - ansible_python_version | length > 0
+    quiet: true
+
+- name: Leave timezone policy disabled for now
+  ansible.builtin.debug:
+    msg: "timezone policy is not managed yet"
+  when: not baseline_timezone_policy_enabled | bool
+
+- name: Leave package policy disabled for now
+  ansible.builtin.debug:
+    msg: "package policy is not managed yet"
+  when: not baseline_packages_policy_enabled | bool

--- a/docs/atlas-host.md
+++ b/docs/atlas-host.md
@@ -1,0 +1,111 @@
+# Atlas Host Role
+
+`atlas_host` prepares or validates hosts that participate in Atlas-operated
+infrastructure management.
+
+The role is intentionally explicit. Daedalus owns the Ansible project,
+inventory, playbooks, roles, and the `infra` command wrapper. Atlas owns the
+script runtime, release installation, command shims, execution logs, and host
+context.
+
+## First Control Node vs Future Control Nodes
+
+`kng01-mgmt-control-01` is manually bootstrapped and already has the minimum
+runtime needed to run `atlas run infra ...`.
+
+For that host:
+
+```yaml
+atlas_bootstrap_mode: manual
+atlas_role: control
+atlas_manage_runtime: false
+atlas_validate_runtime: true
+```
+
+Daedalus validates the active Atlas runtime and renders expected configuration,
+but it does not rebuild the active runtime by default.
+
+The `atlas.yml` playbook treats `kng01-mgmt-control-01` as an Atlas host by
+default without requiring extra inventory changes. Additional hosts should opt in
+with `atlas_enabled: true` when they are ready to be managed by this role.
+
+Future control nodes or replacement control nodes can set
+`atlas_manage_runtime: true` from host or group variables when an already-working
+control node is managing them.
+
+## Runtime Management
+
+`atlas_manage_runtime` controls whether the role runs:
+
+```bash
+atlas runtime install
+```
+
+The default is `false` to avoid replacing the first manually bootstrapped
+runtime by accident.
+
+When runtime management is enabled, the role also force-reinstalls runtime
+packages with the final runtime Python as a workaround for stale console-script
+shebangs.
+
+## Runtime Validation
+
+`atlas_validate_runtime` controls checks that require a working Atlas scripts
+runtime:
+
+- `atlas runtime status`
+- runtime `ansible-inventory --version`
+- optional shebang validation
+
+`atlas_validate_shebangs` controls the shebang check. It defaults to `true`.
+
+## Temporary Directory Policy
+
+Atlas runtime builds should not rely on `/tmp`. Some Ubuntu hosts use a small
+tmpfs there.
+
+Daedalus uses:
+
+```text
+TMPDIR=/opt/atlas/tmp
+PYTHON_BUILD_CACHE_PATH=/var/lib/atlas/cache/python-build
+```
+
+The role creates those directories and writes the environment policy to the
+`ops` user's profile.
+
+## Rendered Configuration
+
+The role renders:
+
+- `/etc/atlas/config.yml`
+- `/etc/atlas/host.yml`
+
+The default Daedalus release source is:
+
+```yaml
+atlas_releases:
+  daedalus:
+    source: daedalus
+
+atlas_registries:
+  daedalus:
+    source: "git+https://github.com/alflag-org/daedalus.git#master"
+```
+
+## Validation Commands
+
+Use the wrapper through Atlas on the control node:
+
+```bash
+atlas run infra inventory --site kanagawa01
+atlas run infra check --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
+atlas run infra diff --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
+```
+
+For DNS LXC reachability and the conservative baseline role:
+
+```bash
+atlas run infra ping --site kanagawa01 --limit kng01-mgmt-recdns-01
+atlas run infra check --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
+```

--- a/docs/bootstrap-control-node.md
+++ b/docs/bootstrap-control-node.md
@@ -1,0 +1,149 @@
+# First Control Node Bootstrap
+
+`kng01-mgmt-control-01` is the first KANAGAWA01 control node. It is the root of
+configuration management for the site and is intentionally bootstrapped by hand.
+
+Daedalus is Atlas-operated and Ansible-backed. It needs Atlas, an Atlas scripts
+runtime, Ansible, SSH material, and Vault password access before it can manage
+hosts. Making Daedalus build that first runtime from a blank host would create a
+circular dependency: the configuration runner would depend on itself before it
+can run.
+
+## Role
+
+`kng01-mgmt-control-01` runs operator-triggered commands such as:
+
+```bash
+atlas run infra inventory --site kanagawa01
+atlas run infra ping --site kanagawa01 --limit kng01-mgmt-recdns-01
+atlas run infra check --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
+```
+
+Daedalus may validate this host and manage non-dangerous configuration on it,
+but it must not rebuild or replace the active Atlas runtime by default.
+
+Future control nodes, replacement control nodes, or control nodes in other sites
+can be provisioned from an already-working control node.
+
+## Minimal Manual Bootstrap
+
+The first control node is expected to have at least:
+
+- OS installation
+- Network configuration
+- `ops` user
+- Required OS packages
+- `pyenv`
+- Atlas CLI
+- `/etc/atlas/config.yml`
+- `/etc/atlas/host.yml`
+- Daedalus release installation
+- Atlas scripts runtime
+- `ansible-core`
+- `~/.ssh/infra`
+- `ANSIBLE_VAULT_PASSWORD`
+
+## Required Paths
+
+- `/etc/atlas`
+- `/opt/atlas`
+- `/opt/atlas/tmp`
+- `/var/lib/atlas`
+- `/var/lib/atlas/cache/python-build`
+- `/home/ops/.local/bin/atlas`
+- `/home/ops/.local/share/atlas-cli-venv`
+- `/home/ops/.ssh/infra`
+
+`/opt/atlas/tmp` is the default runtime build temporary directory for this site.
+`/var/lib/atlas/cache/python-build` is the default Python build cache.
+
+## Required Secrets
+
+Do not commit plaintext secrets.
+
+The Vault password is supplied in one of two ways:
+
+- `ANSIBLE_VAULT_PASSWORD` in the operator environment
+- local, untracked `secrets/ansible_vault.env`
+
+Private SSH keys, real Vault passwords, and generated credentials must stay out
+of git.
+
+## Runtime Validation
+
+Run these commands after manual bootstrap and after changes that affect the
+runtime:
+
+```bash
+atlas status
+atlas runtime status
+atlas scripts list --verbose
+ansible-inventory --version
+atlas run infra inventory --site kanagawa01
+atlas run infra ping --site kanagawa01 --limit kng01-mgmt-recdns-01
+atlas run infra check --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
+atlas run infra check --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
+atlas run infra diff --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
+```
+
+The first control node has `atlas_manage_runtime: false` by default. The Atlas
+playbook should validate the runtime without rebuilding it.
+
+## Known Failure Modes
+
+### Small `/tmp` tmpfs
+
+Ubuntu hosts may mount `/tmp` as a small tmpfs. Python runtime builds can fail
+when `/tmp` is too small.
+
+Use:
+
+```bash
+export TMPDIR=/opt/atlas/tmp
+export PYTHON_BUILD_CACHE_PATH=/var/lib/atlas/cache/python-build
+```
+
+Daedalus also writes these defaults into the `ops` profile for Atlas hosts.
+
+### Atlas Runtime Stale Shebang
+
+Atlas runtime install can leave console scripts with stale shebangs if a virtual
+environment is built in `scripts.tmp` and then renamed to the final runtime
+path.
+
+The operational workaround is to force-reinstall runtime packages with the final
+runtime Python:
+
+```bash
+/opt/atlas/runtime/python/envs/scripts/bin/python \
+  -m pip install --force-reinstall ansible-core 'fire>=0.7' PyYAML
+```
+
+The permanent fix belongs in Atlas, not in Daedalus.
+
+Atlas runtime install should:
+
+1. Create a temporary virtual environment.
+2. Rename it to the final runtime path.
+3. Run `pip install` from the final runtime Python.
+4. Run `pip check` from the final runtime Python.
+5. Validate `bin/*` shebangs.
+6. Fail closed if `scripts.tmp` appears in any console script shebang.
+
+A longer-term design should use versioned runtime directories and a symlink
+switch, for example:
+
+```text
+/opt/atlas/runtime/python/envs/scripts-<build-id>
+/opt/atlas/runtime/python/envs/scripts -> scripts-<build-id>
+```
+
+That avoids mutating the active runtime in place.
+
+### Installed Release Direct Edits
+
+`/opt/atlas/scripts/current/daedalus` is an installed release. Direct edits under
+that path are temporary and are overwritten by release updates.
+
+Persistent changes must be committed to the Daedalus repository, then installed
+or updated through Atlas.


### PR DESCRIPTION
## Summary

- Add the `atlas` playbook and `atlas_host` role for Atlas host validation and future control node provisioning.
- Add a conservative `baseline` role skeleton while preserving the existing debug-style baseline behavior.
- Document the manually bootstrapped `kng01-mgmt-control-01` boundary, Atlas runtime failure modes, and `atlas_host` operation.
- Keep the current `hosts.yml` and existing `host_vars` model intact; DNS examples now use the current `kng01-mgmt-recdns-*` names.

## Verification

Local checks run from this checkout:

```bash
ANSIBLE_VAULT_PASSWORD=dummy ./.venv/bin/infra inventory --site kanagawa01
ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible/ansible.cfg ./.venv/bin/ansible-playbook -i ansible/inventories/kanagawa01/hosts.yml ansible/playbooks/baseline.yml --syntax-check
ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible/ansible.cfg ./.venv/bin/ansible-playbook -i ansible/inventories/kanagawa01/hosts.yml ansible/playbooks/atlas.yml --syntax-check
ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible/ansible.cfg ./.venv/bin/ansible-playbook -i ansible/inventories/kanagawa01/hosts.yml ansible/playbooks/dns.yml --syntax-check
ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible/ansible.cfg ./.venv/bin/ansible-lint --profile min ansible/playbooks/baseline.yml ansible/playbooks/atlas.yml ansible/playbooks/dns.yml
./.venv/bin/python -m compileall modules
git diff --check origin/master...HEAD
```

The live Atlas commands below are intended to run on the deployment/control host, where Atlas, `/home/ops/.ssh/infra`, and the Vault password are present:

```bash
atlas run infra inventory --site kanagawa01
atlas run infra ping --site kanagawa01 --limit kng01-mgmt-recdns-01
atlas run infra check --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
atlas run infra check --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
atlas run infra diff --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
```
