### PR TITLE
feat(ansible): add KANAGAWA01 component roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ infra inventory --site kanagawa01
 - `site`: default steady-state converge
 - `bootstrap`: first converge for a newly added Atlas-managed host
 
-The previous `atlas`, `baseline`, `dns`, `monitoring`, and `containers`
-playbook names remain accepted as temporary compatibility aliases, but they are
-no longer the normal operator menu.
+Focused component playbooks can still be requested explicitly with
+`--playbook`. `atlas`, `baseline`, `dns`, `monitoring`, and `containers` remain
+accepted as temporary compatibility aliases. `cloudflare` is also available as
+an explicit host-side component playbook, but it is not imported into the normal
+`site` converge.
 
 Reachability:
 

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-authdns-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-authdns-01.yml
@@ -1,0 +1,9 @@
+---
+ansible_user: root
+ansible_become: false
+
+dns_authoritative_enabled: true
+dns_authoritative_listen_addresses:
+  - "127.0.0.1"
+  - "10.10.10.242"
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-authdns-02.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-authdns-02.yml
@@ -1,0 +1,9 @@
+---
+ansible_user: root
+ansible_become: false
+
+dns_authoritative_enabled: true
+dns_authoritative_listen_addresses:
+  - "127.0.0.1"
+  - "10.10.10.243"
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-bastion-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-bastion-01.yml
@@ -1,0 +1,7 @@
+---
+ansible_user: root
+ansible_become: false
+
+ssh_server_enabled: true
+cloudflare_ssh_enabled: true
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-connector-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-connector-01.yml
@@ -1,0 +1,6 @@
+---
+ansible_user: root
+ansible_become: false
+
+cloudflared_enabled: true
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-connector-02.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-connector-02.yml
@@ -1,0 +1,6 @@
+---
+ansible_user: root
+ansible_become: false
+
+cloudflared_enabled: true
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-control-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-control-01.yml
@@ -1,4 +1,16 @@
 ---
+ansible_connection: local
+ansible_become: true
+ansible_python_interpreter: /usr/bin/python3
+
+atlas_enabled: true
 atlas_bootstrap_mode: manual
 atlas_role: control
+atlas_runtime_kind: vm
+atlas_manage_scripts: false
+atlas_manage_runtime: false
 atlas_validate_runtime: true
+atlas_validate_shebangs: true
+
+ssh_server_enabled: true
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-recdns-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-recdns-01.yml
@@ -1,0 +1,9 @@
+---
+ansible_user: root
+ansible_become: false
+
+dns_recursor_enabled: true
+dns_recursor_listen_addresses:
+  - "127.0.0.1"
+  - "10.10.10.240"
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-recdns-02.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-recdns-02.yml
@@ -1,0 +1,9 @@
+---
+ansible_user: root
+ansible_become: false
+
+dns_recursor_enabled: true
+dns_recursor_listen_addresses:
+  - "127.0.0.1"
+  - "10.10.10.241"
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-workbench-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-workbench-01.yml
@@ -1,0 +1,7 @@
+---
+ansible_user: root
+ansible_become: false
+
+ssh_server_enabled: true
+cloudflare_ssh_enabled: true
+zabbix_agent_enabled: true

--- a/ansible/playbooks/cloudflare.yml
+++ b/ansible/playbooks/cloudflare.yml
@@ -1,0 +1,3 @@
+---
+- name: Converge explicit Cloudflare host-side components
+  ansible.builtin.import_playbook: components/services/cloudflare.yml

--- a/ansible/playbooks/compat/cloudflare.yml
+++ b/ansible/playbooks/compat/cloudflare.yml
@@ -1,0 +1,3 @@
+---
+- name: Resolve cloudflare playbook alias
+  ansible.builtin.import_playbook: ../components/services/cloudflare.yml

--- a/ansible/playbooks/components/foundation.yml
+++ b/ansible/playbooks/components/foundation.yml
@@ -5,6 +5,10 @@
 
   roles:
     - role: foundation/baseline  # noqa role-name[path]
+    - role: ssh_server
+      when: ssh_server_enabled | default(false)
+    - role: systemd_resolved
+      when: systemd_resolved_enabled | default(false)
     - role: foundation/platform_vm  # noqa role-name[path]
       when: "'platform_vm' in group_names"
     - role: foundation/platform_lxc  # noqa role-name[path]

--- a/ansible/playbooks/components/services/cloudflare.yml
+++ b/ansible/playbooks/components/services/cloudflare.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge Cloudflare host-side components
+  hosts: kanagawa01
+  gather_facts: true
+
+  roles:
+    - role: cloudflared
+      when: cloudflared_enabled | default(false)
+    - role: cloudflare_ssh_target
+      when: cloudflare_ssh_enabled | default(false)

--- a/ansible/playbooks/components/services/containers.yml
+++ b/ansible/playbooks/components/services/containers.yml
@@ -1,7 +1,8 @@
 ---
 - name: Converge container-oriented hosts
-  hosts: svc_container_hosts
+  hosts: kanagawa01
   gather_facts: true
 
   roles:
-    - role: services/containers  # noqa role-name[path]
+    - role: docker_host
+      when: docker_host_enabled | default(false)

--- a/ansible/playbooks/components/services/dns.yml
+++ b/ansible/playbooks/components/services/dns.yml
@@ -1,14 +1,10 @@
 ---
-- name: Converge recursive DNS hosts
-  hosts: svc_dns_recursive
+- name: Converge DNS hosts
+  hosts: kanagawa01
   gather_facts: true
 
   roles:
-    - role: services/dns_recursive  # noqa role-name[path]
-
-- name: Converge authoritative DNS hosts
-  hosts: svc_dns_authoritative
-  gather_facts: true
-
-  roles:
-    - role: services/dns_authoritative  # noqa role-name[path]
+    - role: dns_recursor
+      when: dns_recursor_enabled | default(false)
+    - role: dns_authoritative
+      when: dns_authoritative_enabled | default(false)

--- a/ansible/playbooks/components/services/monitoring.yml
+++ b/ansible/playbooks/components/services/monitoring.yml
@@ -1,7 +1,10 @@
 ---
-- name: Converge monitoring hosts
-  hosts: svc_monitoring
+- name: Converge monitoring agents
+  hosts: kanagawa01
   gather_facts: true
 
   roles:
-    - role: services/monitoring  # noqa role-name[path]
+    - role: zabbix_agent
+      when: zabbix_agent_enabled | default(false)
+    - role: vector_agent
+      when: vector_agent_enabled | default(false)

--- a/ansible/roles/cloudflare_ssh_target/defaults/main.yml
+++ b/ansible/roles/cloudflare_ssh_target/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+cloudflare_ssh_enabled: false  # noqa var-naming[no-role-prefix]
+cloudflare_ssh_hostname: null  # noqa var-naming[no-role-prefix]
+cloudflare_ssh_target_host: localhost
+cloudflare_ssh_target_port: 22
+cloudflare_ssh_mode: self_managed_keys  # noqa var-naming[no-role-prefix]
+cloudflare_ssh_allowed_modes:  # noqa var-naming[no-role-prefix]
+  - self_managed_keys

--- a/ansible/roles/cloudflare_ssh_target/tasks/main.yml
+++ b/ansible/roles/cloudflare_ssh_target/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: Validate Cloudflare SSH target mode
+  ansible.builtin.assert:
+    that:
+      - cloudflare_ssh_mode in cloudflare_ssh_allowed_modes
+    fail_msg: >-
+      Unsupported cloudflare_ssh_mode={{ cloudflare_ssh_mode }}.
+      Daedalus currently manages only host-side SSH target state.
+  when: cloudflare_ssh_enabled | bool
+
+- name: Ensure SSH server is present for Cloudflare SSH target
+  ansible.builtin.include_role:
+    name: ssh_server
+  vars:
+    ssh_server_enabled: true
+  when: cloudflare_ssh_enabled | bool
+
+- name: Validate local SSH target port
+  ansible.builtin.wait_for:
+    host: "{{ cloudflare_ssh_target_host }}"
+    port: "{{ cloudflare_ssh_target_port }}"
+    timeout: 5
+    state: started
+  when:
+    - cloudflare_ssh_enabled | bool
+    - not ansible_check_mode
+
+- name: Record external Cloudflare SSH routing boundary
+  ansible.builtin.debug:
+    msg: >-
+      Cloudflare SSH target {{ cloudflare_ssh_hostname | default(inventory_hostname, true) }}
+      expects a dashboard, Access, or Terraform-managed route to
+      {{ cloudflare_ssh_target_host }}:{{ cloudflare_ssh_target_port }}.
+      Daedalus does not call the Cloudflare API from this role.
+    verbosity: 1
+  when: cloudflare_ssh_enabled | bool

--- a/ansible/roles/cloudflared/defaults/main.yml
+++ b/ansible/roles/cloudflared/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+cloudflared_enabled: false
+cloudflared_service_name: cloudflared
+cloudflared_tunnel_token_env_file: /etc/cloudflared/token.env
+cloudflared_config_dir: /etc/cloudflared
+cloudflared_metrics_enabled: false
+cloudflared_metrics_address: "127.0.0.1"
+cloudflared_metrics_port: 60123
+
+cloudflared_install_method: binary
+cloudflared_package: cloudflared
+cloudflared_binary_path: /usr/local/bin/cloudflared
+cloudflared_binary_arch_assets:
+  x86_64: cloudflared-linux-amd64
+  aarch64: cloudflared-linux-arm64
+  arm64: cloudflared-linux-arm64
+cloudflared_binary_asset: "{{ cloudflared_binary_arch_assets.get(ansible_architecture, 'cloudflared-linux-amd64') }}"
+cloudflared_binary_url: "https://github.com/cloudflare/cloudflared/releases/latest/download/{{ cloudflared_binary_asset }}"
+
+cloudflared_tunnel_token: null
+cloudflared_env_file_mode: "0600"

--- a/ansible/roles/cloudflared/handlers/main.yml
+++ b/ansible/roles/cloudflared/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart cloudflared
+  ansible.builtin.systemd_service:
+    name: "{{ cloudflared_service_name }}"
+    state: restarted
+    enabled: true
+    daemon_reload: true
+  when:
+    - cloudflared_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/cloudflared/tasks/main.yml
+++ b/ansible/roles/cloudflared/tasks/main.yml
@@ -1,0 +1,102 @@
+---
+- name: Require cloudflared tunnel token for apply runs
+  ansible.builtin.assert:
+    that:
+      - cloudflared_tunnel_token is defined
+      - cloudflared_tunnel_token is not none
+      - cloudflared_tunnel_token | string | length > 0
+    fail_msg: >-
+      cloudflared_enabled=true requires cloudflared_tunnel_token from Ansible
+      Vault, a local untracked vars file, or an operator-provided extra var.
+      Cloudflare dashboard resources are not managed by this role.
+  when:
+    - cloudflared_enabled | bool
+    - not ansible_check_mode
+
+- name: Install cloudflared package
+  ansible.builtin.apt:
+    name: "{{ cloudflared_package }}"
+    state: present
+    update_cache: true
+  when:
+    - cloudflared_enabled | bool
+    - cloudflared_install_method == 'package'
+
+- name: Install cloudflared binary
+  ansible.builtin.get_url:
+    url: "{{ cloudflared_binary_url }}"
+    dest: "{{ cloudflared_binary_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - cloudflared_enabled | bool
+    - cloudflared_install_method == 'binary'
+
+- name: Ensure cloudflared config directory exists
+  ansible.builtin.file:
+    path: "{{ cloudflared_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: cloudflared_enabled | bool
+
+- name: Render cloudflared tunnel token environment
+  ansible.builtin.template:
+    src: token.env.j2
+    dest: "{{ cloudflared_tunnel_token_env_file }}"
+    owner: root
+    group: root
+    mode: "{{ cloudflared_env_file_mode }}"
+  no_log: true
+  notify: Restart cloudflared
+  when:
+    - cloudflared_enabled | bool
+    - cloudflared_tunnel_token is defined
+    - cloudflared_tunnel_token is not none
+    - cloudflared_tunnel_token | string | length > 0
+    - not ansible_check_mode
+
+- name: Render cloudflared systemd service
+  ansible.builtin.template:
+    src: cloudflared.service.j2
+    dest: "/etc/systemd/system/{{ cloudflared_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart cloudflared
+  when: cloudflared_enabled | bool
+
+- name: Enable and start cloudflared
+  ansible.builtin.systemd_service:
+    name: "{{ cloudflared_service_name }}"
+    state: started
+    enabled: true
+    daemon_reload: true
+  when:
+    - cloudflared_enabled | bool
+    - not ansible_check_mode
+
+- name: Validate cloudflared version
+  ansible.builtin.command:
+    cmd: "{{ cloudflared_binary_path }} version"
+  changed_when: false
+  when:
+    - cloudflared_enabled | bool
+    - not ansible_check_mode
+
+- name: Gather service facts for cloudflared
+  ansible.builtin.service_facts:
+  when:
+    - cloudflared_enabled | bool
+    - not ansible_check_mode
+
+- name: Validate cloudflared service status
+  ansible.builtin.assert:
+    that:
+      - (ansible_facts.services.get(cloudflared_service_name ~ '.service', {}).state | default('')) == 'running'
+    fail_msg: "cloudflared service {{ cloudflared_service_name }} is not running."
+  when:
+    - cloudflared_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/cloudflared/templates/cloudflared.service.j2
+++ b/ansible/roles/cloudflared/templates/cloudflared.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=cloudflared tunnel service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile={{ cloudflared_tunnel_token_env_file }}
+ExecStart={{ cloudflared_binary_path }} tunnel --no-autoupdate{% if cloudflared_metrics_enabled %} --metrics {{ cloudflared_metrics_address }}:{{ cloudflared_metrics_port }}{% endif %} run --token ${TUNNEL_TOKEN}
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/cloudflared/templates/token.env.j2
+++ b/ansible/roles/cloudflared/templates/token.env.j2
@@ -1,0 +1,1 @@
+TUNNEL_TOKEN={{ cloudflared_tunnel_token | quote }}

--- a/ansible/roles/dns_authoritative/defaults/main.yml
+++ b/ansible/roles/dns_authoritative/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+dns_authoritative_enabled: false
+dns_authoritative_package: nsd
+dns_authoritative_service_name: nsd
+dns_authoritative_config_path: /etc/nsd/nsd.conf
+dns_authoritative_config_dir: "{{ dns_authoritative_config_path | dirname }}"
+dns_authoritative_zone_dir: /etc/nsd/zones
+dns_authoritative_listen_addresses:
+  - "127.0.0.1"
+dns_authoritative_zones: []

--- a/ansible/roles/dns_authoritative/handlers/main.yml
+++ b/ansible/roles/dns_authoritative/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart nsd
+  ansible.builtin.systemd_service:
+    name: "{{ dns_authoritative_service_name }}"
+    state: restarted
+    enabled: true
+  when:
+    - dns_authoritative_enabled | bool
+    - dns_authoritative_zones | length > 0
+    - not ansible_check_mode

--- a/ansible/roles/dns_authoritative/tasks/main.yml
+++ b/ansible/roles/dns_authoritative/tasks/main.yml
@@ -1,0 +1,81 @@
+---
+- name: Install authoritative DNS package
+  ansible.builtin.apt:
+    name: "{{ dns_authoritative_package }}"
+    state: present
+    update_cache: true
+    policy_rc_d: "{{ 101 if dns_authoritative_zones | length == 0 else omit }}"
+  when: dns_authoritative_enabled | bool
+
+- name: Check authoritative DNS config directory
+  ansible.builtin.stat:
+    path: "{{ dns_authoritative_config_dir }}"
+  register: dns_authoritative_config_dir_stat
+  when: dns_authoritative_enabled | bool
+
+- name: Check authoritative DNS zone directory
+  ansible.builtin.stat:
+    path: "{{ dns_authoritative_zone_dir }}"
+  register: dns_authoritative_zone_dir_stat
+  when: dns_authoritative_enabled | bool
+
+- name: Ensure authoritative DNS zone directory exists
+  ansible.builtin.file:
+    path: "{{ dns_authoritative_zone_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: dns_authoritative_enabled | bool
+
+- name: Render authoritative DNS zones from explicit text
+  ansible.builtin.copy:
+    content: "{{ item.text }}"
+    dest: "{{ item.file | default(dns_authoritative_zone_dir ~ '/' ~ item.name ~ '.zone') }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ dns_authoritative_zones }}"
+  notify: Restart nsd
+  when:
+    - dns_authoritative_enabled | bool
+    - item.text is defined
+    - not ansible_check_mode or dns_authoritative_zone_dir_stat.stat.exists
+
+- name: Render authoritative DNS configuration
+  ansible.builtin.template:
+    src: nsd.conf.j2
+    dest: "{{ dns_authoritative_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart nsd
+  when:
+    - dns_authoritative_enabled | bool
+    - not ansible_check_mode or dns_authoritative_config_dir_stat.stat.exists
+
+- name: Validate NSD configuration
+  ansible.builtin.command:
+    cmd: "nsd-checkconf {{ dns_authoritative_config_path }}"
+  changed_when: false
+  when:
+    - dns_authoritative_enabled | bool
+    - not ansible_check_mode
+
+- name: Enable and start NSD when zones are configured
+  ansible.builtin.systemd_service:
+    name: "{{ dns_authoritative_service_name }}"
+    state: started
+    enabled: true
+  when:
+    - dns_authoritative_enabled | bool
+    - dns_authoritative_zones | length > 0
+    - not ansible_check_mode
+
+- name: Leave NSD service external until zones are configured
+  ansible.builtin.debug:
+    msg: "dns_authoritative_enabled=true, but dns_authoritative_zones is empty; NSD service is not started by Daedalus."
+    verbosity: 1
+  when:
+    - dns_authoritative_enabled | bool
+    - dns_authoritative_zones | length == 0

--- a/ansible/roles/dns_authoritative/templates/nsd.conf.j2
+++ b/ansible/roles/dns_authoritative/templates/nsd.conf.j2
@@ -1,0 +1,13 @@
+server:
+  username: nsd
+  zonesdir: "{{ dns_authoritative_zone_dir }}"
+{% for address in dns_authoritative_listen_addresses | unique %}
+  ip-address: {{ address }}
+{% endfor %}
+
+{% for zone in dns_authoritative_zones %}
+zone:
+  name: "{{ zone.name }}"
+  zonefile: "{{ zone.file | default(dns_authoritative_zone_dir ~ '/' ~ zone.name ~ '.zone') }}"
+
+{% endfor %}

--- a/ansible/roles/dns_recursor/defaults/main.yml
+++ b/ansible/roles/dns_recursor/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+dns_recursor_enabled: false
+dns_recursor_package: unbound
+dns_recursor_validation_packages:
+  - dnsutils
+dns_recursor_service_name: unbound
+dns_recursor_config_dir: /etc/unbound/unbound.conf.d
+dns_recursor_config_path: "{{ dns_recursor_config_dir }}/daedalus-recursive.conf"
+dns_recursor_listen_addresses:
+  - "127.0.0.1"
+dns_recursor_allowed_cidrs:
+  - 10.10.0.0/24
+  - 10.10.10.0/24
+  - 10.10.30.0/24
+dns_recursor_local_lookup_name: "."
+dns_recursor_local_lookup_type: NS

--- a/ansible/roles/dns_recursor/handlers/main.yml
+++ b/ansible/roles/dns_recursor/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart unbound
+  ansible.builtin.systemd_service:
+    name: "{{ dns_recursor_service_name }}"
+    state: restarted
+    enabled: true
+  when:
+    - dns_recursor_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/dns_recursor/tasks/main.yml
+++ b/ansible/roles/dns_recursor/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: Install recursive DNS packages
+  ansible.builtin.apt:
+    name: "{{ [dns_recursor_package] + dns_recursor_validation_packages }}"
+    state: present
+    update_cache: true
+  when: dns_recursor_enabled | bool
+
+- name: Check Unbound configuration directory
+  ansible.builtin.stat:
+    path: "{{ dns_recursor_config_dir }}"
+  register: dns_recursor_config_dir_stat
+  when: dns_recursor_enabled | bool
+
+- name: Ensure Unbound configuration directory exists
+  ansible.builtin.file:
+    path: "{{ dns_recursor_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: dns_recursor_enabled | bool
+
+- name: Render recursive DNS configuration
+  ansible.builtin.template:
+    src: daedalus-recursive.conf.j2
+    dest: "{{ dns_recursor_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart unbound
+  when:
+    - dns_recursor_enabled | bool
+    - not ansible_check_mode or dns_recursor_config_dir_stat.stat.exists
+
+- name: Validate Unbound configuration
+  ansible.builtin.command:
+    cmd: unbound-checkconf
+  changed_when: false
+  when:
+    - dns_recursor_enabled | bool
+    - not ansible_check_mode
+
+- name: Enable and start Unbound
+  ansible.builtin.systemd_service:
+    name: "{{ dns_recursor_service_name }}"
+    state: started
+    enabled: true
+  when:
+    - dns_recursor_enabled | bool
+    - not ansible_check_mode
+
+- name: Validate recursive DNS port
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: 53
+    timeout: 5
+    state: started
+  when:
+    - dns_recursor_enabled | bool
+    - not ansible_check_mode
+
+- name: Validate local recursive lookup
+  ansible.builtin.command:
+    cmd: "dig +time=2 +tries=1 +short {{ dns_recursor_local_lookup_name }} {{ dns_recursor_local_lookup_type }} @127.0.0.1"
+  register: dns_recursor_lookup
+  changed_when: false
+  failed_when:
+    - dns_recursor_lookup.rc != 0 or dns_recursor_lookup.stdout | trim | length == 0
+  when:
+    - dns_recursor_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/dns_recursor/templates/daedalus-recursive.conf.j2
+++ b/ansible/roles/dns_recursor/templates/daedalus-recursive.conf.j2
@@ -1,0 +1,17 @@
+server:
+{% for address in dns_recursor_listen_addresses | unique %}
+  interface: {{ address }}
+{% endfor %}
+  port: 53
+  do-ip4: yes
+  do-ip6: no
+  do-udp: yes
+  do-tcp: yes
+  hide-identity: yes
+  hide-version: yes
+  harden-glue: yes
+  harden-dnssec-stripped: yes
+  qname-minimisation: yes
+{% for cidr in dns_recursor_allowed_cidrs | unique %}
+  access-control: {{ cidr }} allow
+{% endfor %}

--- a/ansible/roles/docker_host/defaults/main.yml
+++ b/ansible/roles/docker_host/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+docker_host_enabled: false
+docker_host_packages:
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - docker-buildx-plugin
+  - docker-compose-plugin
+docker_host_apt_keyring_dir: /etc/apt/keyrings
+docker_host_apt_keyring_path: "{{ docker_host_apt_keyring_dir }}/docker.asc"
+docker_host_apt_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
+docker_host_apt_repository: >-
+  deb [arch={{ docker_host_apt_arch }} signed-by={{ docker_host_apt_keyring_path }}]
+  https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable
+docker_host_service_name: docker

--- a/ansible/roles/docker_host/tasks/main.yml
+++ b/ansible/roles/docker_host/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Ensure Docker apt keyring directory exists
+  ansible.builtin.file:
+    path: "{{ docker_host_apt_keyring_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: docker_host_enabled | bool
+
+- name: Install Docker apt key
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    dest: "{{ docker_host_apt_keyring_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  when: docker_host_enabled | bool
+
+- name: Configure Docker apt repository
+  ansible.builtin.apt_repository:
+    repo: "{{ docker_host_apt_repository }}"
+    state: present
+    filename: docker
+  when: docker_host_enabled | bool
+
+- name: Install Docker packages
+  ansible.builtin.apt:
+    name: "{{ docker_host_packages }}"
+    state: present
+    update_cache: true
+  when: docker_host_enabled | bool
+
+- name: Enable and start Docker service
+  ansible.builtin.systemd_service:
+    name: "{{ docker_host_service_name }}"
+    state: started
+    enabled: true
+  when:
+    - docker_host_enabled | bool
+    - not ansible_check_mode
+
+- name: Validate Docker daemon
+  ansible.builtin.command:
+    cmd: docker info
+  changed_when: false
+  when:
+    - docker_host_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/ssh_server/defaults/main.yml
+++ b/ansible/roles/ssh_server/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+ssh_server_enabled: false
+ssh_server_service_name: ssh
+ssh_server_sshd_binary: /usr/sbin/sshd
+ssh_server_config_dropin_dir: /etc/ssh/sshd_config.d
+ssh_server_config_dropin_path: "{{ ssh_server_config_dropin_dir }}/20-daedalus.conf"
+
+ssh_server_permit_root_login: "prohibit-password"
+ssh_server_password_authentication: false
+ssh_server_pubkey_authentication: true
+ssh_server_allow_tcp_forwarding: false
+ssh_server_x11_forwarding: false

--- a/ansible/roles/ssh_server/handlers/main.yml
+++ b/ansible/roles/ssh_server/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart SSH service
+  ansible.builtin.service:
+    name: "{{ ssh_server_service_name }}"
+    state: restarted
+    enabled: true
+  when:
+    - ssh_server_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/ssh_server/tasks/main.yml
+++ b/ansible/roles/ssh_server/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Install OpenSSH server
+  ansible.builtin.apt:
+    name: openssh-server
+    state: present
+    update_cache: true
+  when: ssh_server_enabled | bool
+
+- name: Check sshd drop-in directory
+  ansible.builtin.stat:
+    path: "{{ ssh_server_config_dropin_dir }}"
+  register: ssh_server_dropin_dir
+  when: ssh_server_enabled | bool
+
+- name: Ensure sshd drop-in directory exists
+  ansible.builtin.file:
+    path: "{{ ssh_server_config_dropin_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: ssh_server_enabled | bool
+
+- name: Render managed sshd policy drop-in
+  ansible.builtin.template:
+    src: daedalus.conf.j2
+    dest: "{{ ssh_server_config_dropin_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart SSH service
+  when:
+    - ssh_server_enabled | bool
+    - not ansible_check_mode or ssh_server_dropin_dir.stat.exists
+
+- name: Validate sshd configuration
+  ansible.builtin.command:
+    cmd: "{{ ssh_server_sshd_binary }} -t"
+  changed_when: false
+  when:
+    - ssh_server_enabled | bool
+    - not ansible_check_mode
+
+- name: Enable and start SSH service
+  ansible.builtin.service:
+    name: "{{ ssh_server_service_name }}"
+    state: started
+    enabled: true
+  when:
+    - ssh_server_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/ssh_server/templates/daedalus.conf.j2
+++ b/ansible/roles/ssh_server/templates/daedalus.conf.j2
@@ -1,0 +1,6 @@
+# Managed by Daedalus. Keep this drop-in conservative.
+PermitRootLogin {{ ssh_server_permit_root_login }}
+PasswordAuthentication {{ 'yes' if ssh_server_password_authentication else 'no' }}
+PubkeyAuthentication {{ 'yes' if ssh_server_pubkey_authentication else 'no' }}
+AllowTcpForwarding {{ 'yes' if ssh_server_allow_tcp_forwarding else 'no' }}
+X11Forwarding {{ 'yes' if ssh_server_x11_forwarding else 'no' }}

--- a/ansible/roles/systemd_resolved/defaults/main.yml
+++ b/ansible/roles/systemd_resolved/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+systemd_resolved_enabled: false
+systemd_resolved_manage_resolv_conf: false
+systemd_resolved_dns:
+  - "10.10.10.240"
+  - "10.10.10.241"
+systemd_resolved_domains:
+  - srv.alflag.internal
+systemd_resolved_config_dir: /etc/systemd/resolved.conf.d
+systemd_resolved_config_path: "{{ systemd_resolved_config_dir }}/10-daedalus.conf"
+systemd_resolved_resolv_conf_path: /etc/resolv.conf
+systemd_resolved_resolv_conf_target: /run/systemd/resolve/stub-resolv.conf

--- a/ansible/roles/systemd_resolved/handlers/main.yml
+++ b/ansible/roles/systemd_resolved/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart systemd-resolved
+  ansible.builtin.systemd_service:
+    name: systemd-resolved
+    state: restarted
+    enabled: true
+  when:
+    - systemd_resolved_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/systemd_resolved/tasks/main.yml
+++ b/ansible/roles/systemd_resolved/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Check systemd-resolved configuration directory
+  ansible.builtin.stat:
+    path: "{{ systemd_resolved_config_dir }}"
+  register: systemd_resolved_config_dir_stat
+  when: systemd_resolved_enabled | bool
+
+- name: Ensure systemd-resolved configuration directory exists
+  ansible.builtin.file:
+    path: "{{ systemd_resolved_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: systemd_resolved_enabled | bool
+
+- name: Render systemd-resolved DNS policy
+  ansible.builtin.template:
+    src: daedalus.conf.j2
+    dest: "{{ systemd_resolved_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart systemd-resolved
+  when:
+    - systemd_resolved_enabled | bool
+    - not ansible_check_mode or systemd_resolved_config_dir_stat.stat.exists
+
+- name: Enable and start systemd-resolved
+  ansible.builtin.systemd_service:
+    name: systemd-resolved
+    state: started
+    enabled: true
+  when:
+    - systemd_resolved_enabled | bool
+    - not ansible_check_mode
+
+- name: Manage resolv.conf symlink
+  ansible.builtin.file:
+    src: "{{ systemd_resolved_resolv_conf_target }}"
+    dest: "{{ systemd_resolved_resolv_conf_path }}"
+    state: link
+    force: true
+  when:
+    - systemd_resolved_enabled | bool
+    - systemd_resolved_manage_resolv_conf | bool
+
+- name: Validate systemd-resolved status
+  ansible.builtin.command:
+    cmd: resolvectl status
+  changed_when: false
+  when:
+    - systemd_resolved_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/systemd_resolved/templates/daedalus.conf.j2
+++ b/ansible/roles/systemd_resolved/templates/daedalus.conf.j2
@@ -1,0 +1,3 @@
+[Resolve]
+DNS={{ systemd_resolved_dns | join(' ') }}
+Domains={{ systemd_resolved_domains | join(' ') }}

--- a/ansible/roles/vector_agent/defaults/main.yml
+++ b/ansible/roles/vector_agent/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+vector_agent_enabled: false

--- a/ansible/roles/vector_agent/tasks/main.yml
+++ b/ansible/roles/vector_agent/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Keep Vector agent unmanaged until sinks are defined
+  ansible.builtin.debug:
+    msg: "vector_agent_enabled=true, but the Vector agent implementation is intentionally a disabled skeleton."
+    verbosity: 1
+  when: vector_agent_enabled | bool

--- a/ansible/roles/zabbix_agent/defaults/main.yml
+++ b/ansible/roles/zabbix_agent/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+zabbix_agent_enabled: false
+zabbix_agent_package: zabbix-agent2
+zabbix_server: "10.10.10.250"  # noqa var-naming[no-role-prefix]
+zabbix_server_active: "10.10.10.250"  # noqa var-naming[no-role-prefix]
+zabbix_hostname: "{{ inventory_hostname }}"  # noqa var-naming[no-role-prefix]
+
+zabbix_agent_service_name: zabbix-agent2
+zabbix_agent_config_dir: /etc/zabbix
+zabbix_agent_config_path: "{{ zabbix_agent_config_dir }}/zabbix_agent2.conf"
+zabbix_agent_manage_repository: true
+zabbix_agent_repository_deb_urls:
+  "22.04": "https://repo.zabbix.com/zabbix/6.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_6.0+ubuntu22.04_all.deb"
+  "24.04": "https://repo.zabbix.com/zabbix/7.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_7.0+ubuntu24.04_all.deb"
+zabbix_agent_repository_deb_url: "{{ zabbix_agent_repository_deb_urls.get(ansible_distribution_version, '') }}"

--- a/ansible/roles/zabbix_agent/handlers/main.yml
+++ b/ansible/roles/zabbix_agent/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart zabbix-agent2
+  ansible.builtin.service:
+    name: "{{ zabbix_agent_service_name }}"
+    state: restarted
+    enabled: true
+  when:
+    - zabbix_agent_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/zabbix_agent/tasks/main.yml
+++ b/ansible/roles/zabbix_agent/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+- name: Install Zabbix repository package
+  ansible.builtin.apt:
+    deb: "{{ zabbix_agent_repository_deb_url }}"
+  when:
+    - zabbix_agent_enabled | bool
+    - zabbix_agent_manage_repository | bool
+    - zabbix_agent_repository_deb_url | length > 0
+    - not ansible_check_mode
+
+- name: Install Zabbix agent package
+  ansible.builtin.apt:
+    name: "{{ zabbix_agent_package }}"
+    state: present
+    update_cache: true
+  when:
+    - zabbix_agent_enabled | bool
+    - not ansible_check_mode
+
+- name: Check Zabbix config directory
+  ansible.builtin.stat:
+    path: "{{ zabbix_agent_config_dir }}"
+  register: zabbix_agent_config_dir_stat
+  when: zabbix_agent_enabled | bool
+
+- name: Ensure Zabbix config directory exists
+  ansible.builtin.file:
+    path: "{{ zabbix_agent_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: zabbix_agent_enabled | bool
+
+- name: Render Zabbix agent configuration
+  ansible.builtin.template:
+    src: zabbix_agent2.conf.j2
+    dest: "{{ zabbix_agent_config_path }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart zabbix-agent2
+  when:
+    - zabbix_agent_enabled | bool
+    - not ansible_check_mode or zabbix_agent_config_dir_stat.stat.exists
+
+- name: Enable and start Zabbix agent
+  ansible.builtin.service:
+    name: "{{ zabbix_agent_service_name }}"
+    state: started
+    enabled: true
+  when:
+    - zabbix_agent_enabled | bool
+    - not ansible_check_mode
+
+- name: Gather service facts for Zabbix agent
+  ansible.builtin.service_facts:
+  when:
+    - zabbix_agent_enabled | bool
+    - not ansible_check_mode
+
+- name: Validate Zabbix agent service status
+  ansible.builtin.assert:
+    that:
+      - (ansible_facts.services.get(zabbix_agent_service_name ~ '.service', {}).state | default('')) == 'running'
+    fail_msg: "Zabbix agent service {{ zabbix_agent_service_name }} is not running."
+  when:
+    - zabbix_agent_enabled | bool
+    - not ansible_check_mode

--- a/ansible/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
+++ b/ansible/roles/zabbix_agent/templates/zabbix_agent2.conf.j2
@@ -1,0 +1,7 @@
+# Managed by Daedalus.
+Server={{ zabbix_server }}
+ServerActive={{ zabbix_server_active }}
+Hostname={{ zabbix_hostname }}
+
+Include=/etc/zabbix/zabbix_agent2.d/*.conf
+ControlSocket=/tmp/agent.sock

--- a/docs/atlas-host.md
+++ b/docs/atlas-host.md
@@ -16,11 +16,18 @@ runtime needed to run `atlas run infra ...`.
 For that host:
 
 ```yaml
+ansible_connection: local
+ansible_become: true
+ansible_python_interpreter: /usr/bin/python3
+
+atlas_enabled: true
 atlas_bootstrap_mode: manual
 atlas_role: control
+atlas_runtime_kind: vm
 atlas_manage_scripts: false
 atlas_manage_runtime: false
 atlas_validate_runtime: true
+atlas_validate_shebangs: true
 ```
 
 Daedalus validates the active Atlas runtime and can continue to manage the

--- a/docs/bootstrap-control-node.md
+++ b/docs/bootstrap-control-node.md
@@ -99,9 +99,21 @@ cap_control_node:
 The per-host vars remain:
 
 ```yaml
+ansible_connection: local
+ansible_become: true
+ansible_python_interpreter: /usr/bin/python3
+
+atlas_enabled: true
 atlas_bootstrap_mode: manual
 atlas_role: control
+atlas_runtime_kind: vm
+atlas_manage_scripts: false
+atlas_manage_runtime: false
 atlas_validate_runtime: true
+atlas_validate_shebangs: true
+
+ssh_server_enabled: true
+zabbix_agent_enabled: true
 ```
 
 The default `site` converge should be able to manage the control node after

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -1,0 +1,87 @@
+# Cloudflare Host-Side Components
+
+Daedalus manages only the host-side pieces needed for KANAGAWA01 Cloudflare
+connectivity:
+
+- `cloudflared` installation
+- `/etc/cloudflared` ownership and token environment file rendering
+- the local `cloudflared` systemd service
+- conservative local SSH server policy for Cloudflare SSH targets
+- local validation that SSH is reachable on the expected host and port
+
+Daedalus does not manage Cloudflare dashboard or API resources yet.
+
+## Tunnel Tokens
+
+Do not commit tunnel tokens.
+
+For apply runs, `cloudflared_enabled=true` requires:
+
+```yaml
+cloudflared_tunnel_token: "{{ vault_cloudflared_tunnel_token }}"
+```
+
+The value can come from Ansible Vault, a local untracked vars file, or an
+operator-provided extra var. Daedalus renders:
+
+```text
+/etc/cloudflared/token.env
+```
+
+with mode `0600`. Check mode does not require the token so operators can review
+planned host changes without committing or exposing secret material.
+
+## cloudflared Service
+
+The service executes the local tunnel in token mode:
+
+```text
+cloudflared tunnel --no-autoupdate run --token "$TUNNEL_TOKEN"
+```
+
+Metrics are disabled by default. Enable them with:
+
+```yaml
+cloudflared_metrics_enabled: true
+cloudflared_metrics_address: 127.0.0.1
+cloudflared_metrics_port: 60123
+```
+
+## Cloudflare SSH Targets
+
+`cloudflare_ssh_target` prepares a host so Cloudflare Access SSH or Tunnel can
+reach a local SSH daemon. The role depends on the local `ssh_server` role and
+validates `cloudflare_ssh_target_host:cloudflare_ssh_target_port` from the
+managed host.
+
+It does not create:
+
+- Access applications
+- Access policies
+- tunnel routes
+- private hostnames
+- DNS records
+
+Those resources remain manual, dashboard-managed, or Terraform-managed future
+work.
+
+## Validation
+
+Focused checks from the control node:
+
+```bash
+atlas run infra check --site kanagawa01 --playbook cloudflare --limit kng01-mgmt-connector-01
+atlas run infra check --site kanagawa01 --playbook cloudflare --limit kng01-mgmt-bastion-01
+```
+
+After apply, validate local host-side state:
+
+```bash
+cloudflared version
+systemctl is-active cloudflared
+sshd -t
+```
+
+External reachability through Access or a private hostname must be validated
+outside Daedalus until Cloudflare-side state is brought under Terraform or
+another explicit management path.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,99 @@
+# KANAGAWA01 Components
+
+Daedalus models KANAGAWA01 host configuration as inventory-selected
+components. Inventory describes which hosts exist, their network zone, platform
+class, and enabled component flags. Roles implement host-side state only.
+
+## Playbooks
+
+The steady-state entrypoint is:
+
+```bash
+atlas run infra check --site kanagawa01
+```
+
+Public compatibility playbook names still exist for focused runs:
+
+```bash
+atlas run infra check --site kanagawa01 --playbook baseline
+atlas run infra check --site kanagawa01 --playbook dns
+atlas run infra check --site kanagawa01 --playbook monitoring
+atlas run infra check --site kanagawa01 --playbook containers
+atlas run infra check --site kanagawa01 --playbook cloudflare
+atlas run infra check --site kanagawa01 --playbook atlas
+```
+
+`cloudflare` is intentionally explicit and is not imported into `site.yml`.
+Cloudflare tunnel tokens are required for apply runs on connector hosts, so
+operators should target that playbook deliberately.
+
+## Implemented Roles
+
+| Role | Flag | Purpose |
+| --- | --- | --- |
+| `ssh_server` | `ssh_server_enabled` | Installs OpenSSH server, writes a conservative drop-in, validates `sshd -t`, and restarts SSH only after config changes. |
+| `cloudflared` | `cloudflared_enabled` | Installs cloudflared, writes a token environment file from operator-provided secret vars, installs the systemd service, and validates local service state. |
+| `cloudflare_ssh_target` | `cloudflare_ssh_enabled` | Ensures local SSH is available for Cloudflare Access SSH or Tunnel routing. It performs no Cloudflare API calls. |
+| `systemd_resolved` | `systemd_resolved_enabled` | Configures systemd-resolved. `/etc/resolv.conf` is managed only when `systemd_resolved_manage_resolv_conf` is true. |
+| `dns_recursor` | `dns_recursor_enabled` | Installs and configures Unbound for recursive DNS hosts. |
+| `dns_authoritative` | `dns_authoritative_enabled` | Installs and minimally configures NSD. It starts the service only when zones are explicitly provided. |
+| `zabbix_agent` | `zabbix_agent_enabled` | Installs and configures `zabbix-agent2` on managed hosts. |
+| `docker_host` | `docker_host_enabled` | Prepares Docker hosts only when explicitly enabled. No application containers are deployed. |
+| `vector_agent` | `vector_agent_enabled` | Reserved skeleton for future log forwarding. It does not configure external sinks. |
+
+All risky roles default to disabled. Host vars opt a host into the components it
+should run.
+
+## Host Responsibility
+
+Current KANAGAWA01 component flags are:
+
+| Host | Connection policy | Components |
+| --- | --- | --- |
+| `kng01-mgmt-control-01` | local connection, `ops + become` | Atlas control host validation, SSH server, Zabbix agent |
+| `kng01-mgmt-recdns-01` | LXC root, no become | Recursive DNS, Zabbix agent |
+| `kng01-mgmt-recdns-02` | LXC root, no become | Recursive DNS, Zabbix agent |
+| `kng01-mgmt-authdns-01` | LXC root, no become | Authoritative DNS foundation, Zabbix agent |
+| `kng01-mgmt-authdns-02` | LXC root, no become | Authoritative DNS foundation, Zabbix agent |
+| `kng01-mgmt-connector-01` | LXC root, no become | cloudflared, Zabbix agent |
+| `kng01-mgmt-connector-02` | LXC root, no become | cloudflared, Zabbix agent |
+| `kng01-mgmt-bastion-01` | LXC root, no become | SSH server, Cloudflare SSH target, Zabbix agent |
+| `kng01-mgmt-workbench-01` | LXC root, no become | SSH server, Cloudflare SSH target, Zabbix agent |
+
+The LXC connection policy reflects the current inventory state. VM hosts should
+use the normal `ops + become` model unless host-specific reality says
+otherwise.
+
+## External State
+
+Daedalus does not currently manage:
+
+- Cloudflare Access applications
+- Cloudflare tunnel routes
+- Cloudflare private hostnames
+- Cloudflare dashboard state
+- Zabbix server provisioning
+- application containers
+- authoritative DNS zone migration unless `dns_authoritative_zones` explicitly
+  provides zone text
+
+Those boundaries are deliberate. They can move to Terraform or a future
+Daedalus component after the host-side state is stable.
+
+## Validation
+
+On the control node, use:
+
+```bash
+atlas run infra inventory --site kanagawa01
+atlas run infra check --site kanagawa01 --playbook baseline --limit kng01-mgmt-recdns-01
+atlas run infra check --site kanagawa01 --playbook dns --limit kng01-mgmt-recdns-01
+atlas run infra check --site kanagawa01 --playbook cloudflare --limit kng01-mgmt-connector-01
+atlas run infra check --site kanagawa01 --playbook cloudflare --limit kng01-mgmt-bastion-01
+atlas run infra check --site kanagawa01 --playbook monitoring --limit kng01-mgmt-recdns-01
+atlas run infra check --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
+```
+
+Local development machines may lack Atlas runtime, Vault password material, or
+`~/.ssh/infra`. In that case, use repository-local syntax checks as a static
+guard and run the commands above from `kng01-mgmt-control-01`.

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -20,9 +20,19 @@ ansible/
   playbooks/
     site.yml
     bootstrap.yml
+    cloudflare.yml
     components/
     compat/
   roles/
+    ssh_server/
+    cloudflared/
+    cloudflare_ssh_target/
+    systemd_resolved/
+    dns_recursor/
+    dns_authoritative/
+    zabbix_agent/
+    docker_host/
+    vector_agent/
     foundation/
     control/
     services/
@@ -54,4 +64,5 @@ Within `ansible/`, the boundaries are:
 - `roles/foundation/`: host baseline and platform roles
 - `roles/control/`: Atlas control-plane roles
 - `roles/services/`: service-intent roles selected by `svc_*` inventory groups
+- `roles/<component>/`: component implementation roles selected by host vars
 - `roles/legacy/`: controller-local or not-yet-migrated roles excluded from normal site converge

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,6 +14,9 @@ public playbook entrypoint.
 Normal steady-state runs should use the default `site` playbook and narrow the
 target with `--limit <inventory-group-or-host>` when needed. Reserve
 `--playbook bootstrap` for first converge on a newly added Atlas-managed host.
+Use `--playbook cloudflare` deliberately for host-side Cloudflare components;
+it is not part of the default `site` converge because connector hosts require
+operator-provided tunnel tokens for apply runs.
 
 `apply` is the only mutating action and requires `--yes`. Run `check` or `diff`
 first unless there is a clear operational reason not to.

--- a/modules/daedalus/paths.py
+++ b/modules/daedalus/paths.py
@@ -7,6 +7,7 @@ PUBLIC_PLAYBOOKS = ("site", "bootstrap")
 DEPRECATED_PLAYBOOK_ALIASES = {
     "atlas": "compat/atlas.yml",
     "baseline": "compat/baseline.yml",
+    "cloudflare": "compat/cloudflare.yml",
     "dns": "compat/dns.yml",
     "monitoring": "compat/monitoring.yml",
     "containers": "compat/containers.yml",


### PR DESCRIPTION
## Summary

- add KANAGAWA01 host vars for control, DNS, connector, bastion, and workbench hosts
- add host-side component roles for SSH, cloudflared, Cloudflare SSH targets, DNS, systemd-resolved, Zabbix agent, Docker, and Vector foundation
- add an explicit Cloudflare playbook and docs while keeping Cloudflare dashboard/API state external
- keep tunnel tokens out of git and require them from operator-provided variables for apply runs

## Verification

- `git diff --check`
- `python -m compileall commands modules`
- `ANSIBLE_VAULT_PASSWORD=dummy uv run infra inventory --site kanagawa01`
- `ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible.cfg uv run --project .. ansible-playbook -i inventories/kanagawa01/hosts.yml playbooks/site.yml --syntax-check`
- `ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible.cfg uv run --project .. ansible-playbook -i inventories/kanagawa01/hosts.yml playbooks/cloudflare.yml --syntax-check`
- `ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible.cfg uv run --project .. ansible-playbook -i inventories/kanagawa01/hosts.yml playbooks/compat/{baseline,cloudflare,dns,monitoring,containers,atlas}.yml --syntax-check`
- `ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_CONFIG=ansible.cfg uv run --project .. --with ansible-lint ansible-lint playbooks/cloudflare.yml playbooks/compat/cloudflare.yml playbooks/compat/dns.yml playbooks/compat/monitoring.yml playbooks/compat/containers.yml playbooks/compat/baseline.yml`
- `ANSIBLE_VAULT_PASSWORD=dummy uv run infra check --site kanagawa01 --playbook cloudflare --limit kng01-mgmt-control-01`

## Notes

The connector-host check from this local workstation is unreachable because `/home/ops/.ssh/infra` is not present here. Run the host-targeted check commands from `kng01-mgmt-control-01`, where Atlas, Vault material, and SSH keys are expected to exist.
