### PR TITLE
[codex] Add kng01 Zabbix VM inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ Inventory is now the primary place where host responsibility is expressed.
 - `cap_*` groups describe shared control-plane capabilities, for example
   `cap_atlas_host` and `cap_control_node`.
 - `svc_*` groups describe service intent, for example `svc_dns_recursive`,
-  `svc_dns_authoritative`, `svc_connector`, `svc_bastion`, and `svc_workbench`.
+  `svc_dns_authoritative`, `svc_connector`, `svc_bastion`, `svc_workbench`, and
+  `svc_zabbix`.
 
 Playbooks are no longer the place where service intent is modeled. The public
 playbooks only define lifecycle boundaries: `site` for steady-state converge and
@@ -274,6 +275,12 @@ Bootstrap a cloud-init VM with:
 infra apply --yes --site kanagawa01 --playbook bootstrap --limit <new-host>
 ```
 
+Then run the steady-state converge for that host:
+
+```bash
+infra apply --yes --site kanagawa01 --limit <new-host>
+```
+
 Bootstrap a root-only LXC with the same playbook, but override the first login
 user for that one run:
 
@@ -283,7 +290,9 @@ infra apply --yes --site kanagawa01 --playbook bootstrap --limit <new-host> \
 ```
 
 After that first run, use the normal `site` converge with the standard `ops`
-connection model.
+connection model. The bootstrap playbook applies the platform foundation to
+regular managed hosts. Atlas runtime setup is limited to hosts in
+`cap_atlas_host`.
 
 ## State
 

--- a/ansible/inventories/kanagawa01/group_vars/svc_zabbix.yml
+++ b/ansible/inventories/kanagawa01/group_vars/svc_zabbix.yml
@@ -1,0 +1,8 @@
+---
+zabbix_primary_problem_source: true
+zabbix_server_installation_managed: false
+zabbix_intended_components:
+  - zabbix-server
+  - zabbix-frontend
+  - zabbix-agent2
+  - local-database

--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-zabbix-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-zabbix-01.yml
@@ -1,0 +1,31 @@
+---
+hostname: kng01-mgmt-zabbix-01
+site: kng01
+zone: mgmt
+role: zabbix
+virtualization_type: vm
+os_distribution: Ubuntu
+os_version: "26.04"
+
+network_address: 10.10.10.250/24
+network_ipv4_address: 10.10.10.250
+network_prefix_length: 24
+network_gateway: 10.10.10.1
+network_dns_resolvers:
+  - 10.10.10.240
+  - 10.10.10.241
+network_primary_fqdn: kng01-mgmt-zabbix-01.srv.alflag.internal
+network_service_aliases:
+  - zabbix.alflag.internal
+
+systemd_resolved_dns:
+  - 10.10.10.240
+  - 10.10.10.241
+systemd_resolved_domains:
+  - srv.alflag.internal
+
+ssh_server_enabled: true
+systemd_resolved_enabled: true
+foundation_vm_skip_systemd_resolved: true
+foundation_vm_skip_zabbix_agent: true
+zabbix_agent_enabled: true

--- a/ansible/inventories/kanagawa01/hosts.yml
+++ b/ansible/inventories/kanagawa01/hosts.yml
@@ -13,8 +13,8 @@ all:
               ansible_host: 10.10.10.242
             kng01-mgmt-authdns-02:
               ansible_host: 10.10.10.243
-            # kng01-mgmt-zabbix-01:
-            #   ansible_host: 10.10.10.250
+            kng01-mgmt-zabbix-01:
+              ansible_host: 10.10.10.250
             kng01-mgmt-connector-01:
               ansible_host: 10.10.10.41
             kng01-mgmt-connector-02:
@@ -40,6 +40,7 @@ all:
             kng01-mgmt-recdns-02: {}
             kng01-mgmt-authdns-01: {}
             kng01-mgmt-authdns-02: {}
+            kng01-mgmt-zabbix-01: {}
             kng01-mgmt-connector-01: {}
             kng01-mgmt-connector-02: {}
             kng01-mgmt-bastion-01: {}
@@ -61,6 +62,7 @@ all:
         platform_vm:
           hosts:
             kng01-mgmt-control-01: {}
+            kng01-mgmt-zabbix-01: {}
             kng01-dmz-web-01: {}
 
         cap_atlas_host:
@@ -93,6 +95,10 @@ all:
         svc_workbench:
           hosts:
             kng01-mgmt-workbench-01: {}
+
+        svc_zabbix:
+          hosts:
+            kng01-mgmt-zabbix-01: {}
 
         svc_web:
           hosts:

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -1,8 +1,14 @@
 ---
-- name: Bootstrap new hosts for Atlas management
-  hosts: cap_atlas_host
+- name: Bootstrap new hosts for configuration management
+  hosts: kanagawa01
   gather_facts: true
 
   roles:
     - role: foundation/bootstrap  # noqa role-name[path]
+
+- name: Bootstrap Atlas runtime hosts
+  hosts: cap_atlas_host
+  gather_facts: true
+
+  roles:
     - role: control/atlas_host  # noqa role-name[path]

--- a/ansible/playbooks/components/services.yml
+++ b/ansible/playbooks/components/services.yml
@@ -13,3 +13,6 @@
 
 - name: Converge workbench services
   ansible.builtin.import_playbook: services/workbench.yml
+
+- name: Converge Zabbix services
+  ansible.builtin.import_playbook: services/zabbix.yml

--- a/ansible/playbooks/components/services/zabbix.yml
+++ b/ansible/playbooks/components/services/zabbix.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge Zabbix service hosts
+  hosts: svc_zabbix
+  gather_facts: true
+
+  roles:
+    - role: zabbix_agent
+      when: zabbix_agent_enabled | default(false)

--- a/ansible/roles/zabbix_agent/defaults/main.yml
+++ b/ansible/roles/zabbix_agent/defaults/main.yml
@@ -10,6 +10,14 @@ zabbix_agent_config_dir: /etc/zabbix
 zabbix_agent_config_path: "{{ zabbix_agent_config_dir }}/zabbix_agent2.conf"
 zabbix_agent_manage_repository: true
 zabbix_agent_repository_deb_urls:
-  "22.04": "https://repo.zabbix.com/zabbix/6.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_6.0+ubuntu22.04_all.deb"
-  "24.04": "https://repo.zabbix.com/zabbix/7.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_7.0+ubuntu24.04_all.deb"
-zabbix_agent_repository_deb_url: "{{ zabbix_agent_repository_deb_urls.get(ansible_facts.get('distribution_version', ''), '') }}"
+  "22.04": >-
+    https://repo.zabbix.com/zabbix/6.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_6.0+ubuntu22.04_all.deb
+  "24.04": >-
+    https://repo.zabbix.com/zabbix/7.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_7.0+ubuntu24.04_all.deb
+  "26.04": >-
+    https://repo.zabbix.com/zabbix/7.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_7.0+ubuntu26.04_all.deb
+zabbix_agent_repository_deb_url: >-
+  {{ zabbix_agent_repository_deb_urls.get(
+    ansible_facts.get('distribution_version', ''),
+    ''
+  ) }}

--- a/docs/atlas-host.md
+++ b/docs/atlas-host.md
@@ -87,8 +87,13 @@ infra apply --yes --site kanagawa01 --playbook bootstrap --limit <new-host> \
 The playbook branches inside `common/bootstrap`: VM and LXC hosts share one
 entrypoint, and the role selects the platform-specific tasks after fact
 gathering. For the root-only LXC case, that run connects as `root`, creates and
-authorizes `ops`, installs passwordless sudo, and prepares the Atlas host
-layout. After it succeeds, switch back to the normal `site` converge.
+authorizes `ops`, and installs passwordless sudo. After it succeeds, switch back
+to the normal `site` converge.
+
+The same public bootstrap playbook also prepares Atlas runtime hosts, but only
+for inventory members of `cap_atlas_host`. Regular service hosts can use
+bootstrap for operator access and platform foundation without becoming Atlas
+runtime hosts.
 
 ## Scripts Release Management
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -60,6 +60,7 @@ Current KANAGAWA01 component flags are:
 | `kng01-mgmt-connector-02` | LXC root, no become | cloudflared, Zabbix agent |
 | `kng01-mgmt-bastion-01` | LXC root, no become | SSH server, Cloudflare SSH target, Zabbix agent |
 | `kng01-mgmt-workbench-01` | LXC root, no become | SSH server, Cloudflare SSH target, Zabbix agent |
+| `kng01-mgmt-zabbix-01` | VM `ops + become` | Zabbix server/frontend/local DB intent, Zabbix agent |
 | `kng01-dmz-web-01` | VM `ops + become` | SSH server, cloudflared host-side readiness, Cloudflare SSH target, localhost nginx Web origin, Zabbix agent |
 
 The LXC connection policy reflects the current inventory state. VM hosts should
@@ -75,6 +76,50 @@ The host is opted into the existing `cloudflared` role, but apply runs still
 require `cloudflared_tunnel_token` from Vault, an untracked vars file, or an
 operator-provided extra var.
 
+`kng01-mgmt-zabbix-01` is reserved for the primary Zabbix service in VLAN 110
+because monitoring and problem triage are management-plane responsibilities.
+The inventory classifies it as an Ubuntu 26.04 Proxmox VM in `kng01_mgmt`,
+`platform_vm`, and `svc_zabbix`. Daedalus manages the VM foundation, SSH policy,
+systemd-resolved policy, and `zabbix-agent2` for the host. The `svc_zabbix`
+group also records the intended full Zabbix stack (`zabbix-server`,
+`zabbix-frontend`, `zabbix-agent2`, and a local database), but Daedalus does not
+yet wire that service intent to a full Zabbix Server converge role. The VM is
+expected to exist before Daedalus runs; Daedalus manages the guest configuration
+after it is reachable at `10.10.10.250`.
+
+Prometheus, Grafana, Alertmanager, Zabbix HA, and historical Zabbix database
+migration are intentionally out of scope for this host definition.
+
+## Network Allocation
+
+| Host | Zone | VLAN | Address | Gateway |
+| --- | --- | ---: | --- | --- |
+| `kng01-mgmt-connector-01` | mgmt | 110 | `10.10.10.41/24` | `10.10.10.1` |
+| `kng01-mgmt-connector-02` | mgmt | 110 | `10.10.10.42/24` | `10.10.10.1` |
+| `kng01-mgmt-bastion-01` | mgmt | 110 | `10.10.10.60/24` | `10.10.10.1` |
+| `kng01-mgmt-workbench-01` | mgmt | 110 | `10.10.10.61/24` | `10.10.10.1` |
+| `kng01-mgmt-control-01` | mgmt | 110 | `10.10.10.62/24` | `10.10.10.1` |
+| `kng01-mgmt-recdns-01` | mgmt | 110 | `10.10.10.240/24` | `10.10.10.1` |
+| `kng01-mgmt-recdns-02` | mgmt | 110 | `10.10.10.241/24` | `10.10.10.1` |
+| `kng01-mgmt-authdns-01` | mgmt | 110 | `10.10.10.242/24` | `10.10.10.1` |
+| `kng01-mgmt-authdns-02` | mgmt | 110 | `10.10.10.243/24` | `10.10.10.1` |
+| `kng01-mgmt-zabbix-01` | mgmt | 110 | `10.10.10.250/24` | `10.10.10.1` |
+| `kng01-dmz-web-01` | dmz | 130 | `10.10.30.21/24` | `10.10.30.1` |
+
+KANAGAWA01 recursive DNS resolvers are `10.10.10.240` and `10.10.10.241`.
+`kng01-mgmt-zabbix-01` uses those resolver addresses in inventory metadata.
+
+## Required Internal DNS Records
+
+Daedalus does not currently keep `alflag.internal` zone records as managed
+inventory data. Until that source of truth moves into Daedalus, create or verify
+these records in the authoritative internal DNS system:
+
+| Name | Type | Value |
+| --- | --- | --- |
+| `kng01-mgmt-zabbix-01.srv.alflag.internal` | A | `10.10.10.250` |
+| `zabbix.alflag.internal` | CNAME | `kng01-mgmt-zabbix-01.srv.alflag.internal` |
+
 ## External State
 
 Daedalus does not currently manage:
@@ -85,6 +130,7 @@ Daedalus does not currently manage:
 - Cloudflare private hostnames
 - Cloudflare dashboard state
 - Zabbix server provisioning
+- Prometheus, Grafana, or Alertmanager deployment
 - application containers
 - authoritative DNS zone migration unless `dns_authoritative_zones` explicitly
   provides zone text
@@ -104,6 +150,9 @@ atlas run infra check --site kanagawa01 --playbook cloudflare --limit kng01-mgmt
 atlas run infra check --site kanagawa01 --playbook cloudflare --limit kng01-mgmt-bastion-01
 atlas run infra check --site kanagawa01 --playbook monitoring --limit kng01-mgmt-recdns-01
 atlas run infra check --site kanagawa01 --playbook atlas --limit kng01-mgmt-control-01
+atlas run infra ping --site kanagawa01 --limit kng01-mgmt-zabbix-01
+atlas run infra check --site kanagawa01 --playbook bootstrap --limit kng01-mgmt-zabbix-01
+atlas run infra check --site kanagawa01 --limit kng01-mgmt-zabbix-01
 atlas run infra ping --site kanagawa01 --limit kng01-dmz-web-01
 atlas run infra check --site kanagawa01 --limit kng01-dmz-web-01
 atlas run infra check --site kanagawa01 --playbook cloudflare --limit kng01-dmz-web-01


### PR DESCRIPTION
## Summary
- Add `kng01-mgmt-zabbix-01` to the KANAGAWA01 inventory as a Proxmox VM in the MGMT zone.
- Add `svc_zabbix` service intent and wire the host to the existing Zabbix Agent2 role.
- Update bootstrap targeting so regular managed hosts can be bootstrapped without becoming Atlas runtime hosts.
- Document IP allocation, required internal DNS records, Ubuntu 26.04 support, and out-of-scope Zabbix server work.

## Validation
- `ANSIBLE_CONFIG=ansible.cfg ANSIBLE_VAULT_PASSWORD=dummy ../.venv/bin/ansible-playbook -i inventories/kanagawa01/hosts.yml playbooks/bootstrap.yml --syntax-check`
- `ANSIBLE_CONFIG=ansible.cfg ANSIBLE_VAULT_PASSWORD=dummy ../.venv/bin/ansible-playbook -i inventories/kanagawa01/hosts.yml playbooks/site.yml --syntax-check`
- `ANSIBLE_CONFIG=ansible.cfg ANSIBLE_VAULT_PASSWORD=dummy ../.venv/bin/ansible-lint playbooks/bootstrap.yml playbooks/site.yml`
- `.venv/bin/yamllint ansible/roles/zabbix_agent/defaults/main.yml ansible/inventories/kanagawa01/host_vars/kng01-mgmt-zabbix-01.yml ansible/inventories/kanagawa01/group_vars/svc_zabbix.yml ansible/playbooks/components/services/zabbix.yml`
- `ANSIBLE_VAULT_PASSWORD=dummy .venv/bin/infra inventory --site kanagawa01`
- `ansible` debug confirmed Ubuntu 26.04 resolves to the Zabbix 7.0 repository package URL.

## Notes
- VM creation and all apply runs are left to the operator.
- Zabbix Server, frontend, local DB provisioning, historical DB migration, Prometheus, Grafana, and Alertmanager remain out of scope.