### PR TITLE
[codex] Fix Zabbix secret preflight warning

### DIFF
--- a/ansible/roles/middleware/zabbix-server/tasks/preflight.yml
+++ b/ansible/roles/middleware/zabbix-server/tasks/preflight.yml
@@ -11,8 +11,7 @@
 - name: Validate required Zabbix database secret variables
   ansible.builtin.assert:
     that:
-      - item in vars
-      - (vars[item] | default('') | string | length) > 0
+      - (lookup('ansible.builtin.vars', item, default='') | string | length) > 0
     fail_msg: >-
       Required secret variable {{ item }} is missing. Provide it through
       Ansible Vault, an untracked vars file, or --extra-vars before enabling

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,3 +24,19 @@ first unless there is a clear operational reason not to.
 Keep plaintext secrets out of git. Use `secrets/ansible_vault.env` for local
 Vault password material and keep shared secret values in the agreed operator
 secret store.
+
+For the managed Zabbix server, apply runs require these database variables:
+
+```yaml
+mysql_root_password: ...
+mysql_zabbix_password: ...
+mysql_zabbix_monitor_password: ...
+```
+
+Pass them from Vault or from an operator-local file outside the repository, for
+example:
+
+```bash
+atlas run infra apply --yes --site kanagawa01 --limit kng01-mgmt-zabbix-01 \
+  --extra-vars @/home/ops/.config/daedalus/zabbix-db.yml
+```


### PR DESCRIPTION
## Summary

- Replace the deprecated direct `vars` dictionary lookup in the Zabbix preflight with the supported `vars` lookup plugin.
- Document the required Zabbix database variables and an operator-local `--extra-vars` handoff path.

## Validation

- `git diff --check`
- `ANSIBLE_VAULT_PASSWORD=dummy ANSIBLE_COLLECTIONS_PATH="$PWD/collections:$tmpdir" uv run --with ansible-core ansible-playbook --syntax-check playbooks/site.yml`