### PR TITLE
[codex] Auto-load operator vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,12 +220,27 @@ That inventory declaration is the source of truth for what the host should run.
 Do not commit plaintext secrets. Pass operator-only secret values from the
 agreed secret store or from local files outside this repository.
 
+The `infra` wrapper automatically loads a site-local operator vars file when it
+exists:
+
+```text
+~/.config/daedalus/<site>.yml
+~/.config/daedalus/<site>.yaml
+~/.config/daedalus/<site>.json
+```
+
+For KANAGAWA01, the default path is `~/.config/daedalus/kanagawa01.yml`.
+Set `DAEDALUS_OPERATOR_VARS=/path/to/vars.yml` to use a different file.
+Explicit `--extra-vars` values are still supported and are passed after the
+auto-loaded file.
+
 ## Local Development
 
 Install the Python package in editable mode when working without Atlas:
 
 ```bash
 python -m pip install -e .
+python -m unittest discover -s tests
 infra sites
 infra playbooks
 infra inventory

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -21,8 +21,8 @@ For apply runs, `cloudflared_enabled=true` requires:
 cloudflared_tunnel_token: "..."
 ```
 
-The value can come from the operator secret store, a local untracked vars file,
-or an operator-provided extra var. Daedalus renders:
+The value can come from the operator secret store, the site-local operator vars
+file loaded by `infra`, or an operator-provided extra var. Daedalus renders:
 
 ```text
 /etc/cloudflared/token.env

--- a/docs/components.md
+++ b/docs/components.md
@@ -88,10 +88,10 @@ Zabbix server/frontend packages for the host. The managed frontend listens on
 HTTP port 80 through Caddy and serves `zabbix.alflag.internal` via the host's
 normal management-plane address. Apply runs require the database secret vars
 `mysql_root_password`, `mysql_zabbix_password`, and
-`mysql_zabbix_monitor_password` from the operator secret store, an untracked
-vars file, or operator-provided extra vars. The VM is expected to exist before
-Daedalus runs; Daedalus manages the guest configuration after it is reachable at
-`10.10.10.250`.
+`mysql_zabbix_monitor_password` from the operator secret store, the site-local
+operator vars file loaded by `infra`, or operator-provided extra vars. The VM is
+expected to exist before Daedalus runs; Daedalus manages the guest configuration
+after it is reachable at `10.10.10.250`.
 
 Prometheus, Grafana, Alertmanager, Zabbix HA, and historical Zabbix database
 migration are intentionally out of scope for this host definition.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,6 +25,19 @@ Keep plaintext secrets out of git. Keep shared secret values in the agreed
 operator secret store, and pass operator-local vars from files outside this
 repository.
 
+The `infra` wrapper automatically loads the first existing site-local operator
+vars file from:
+
+```text
+~/.config/daedalus/<site>.yml
+~/.config/daedalus/<site>.yaml
+~/.config/daedalus/<site>.json
+```
+
+Set `DAEDALUS_OPERATOR_VARS=/path/to/vars.yml` when an operator run needs a
+different file. Explicit `--extra-vars` still works and is applied after the
+auto-loaded file.
+
 For the managed Zabbix server, apply runs require these database variables:
 
 ```yaml
@@ -33,10 +46,20 @@ mysql_zabbix_password: ...
 mysql_zabbix_monitor_password: ...
 ```
 
-Pass them from the operator secret store or from an operator-local file outside
-the repository, for example:
+Store them in the KANAGAWA01 operator vars file:
 
 ```bash
-atlas run infra apply --yes --site kanagawa01 --limit kng01-mgmt-zabbix-01 \
-  --extra-vars @/home/ops/.config/daedalus/zabbix-db.yml
+mkdir -p /home/ops/.config/daedalus
+umask 077
+cat > /home/ops/.config/daedalus/kanagawa01.yml <<'EOF'
+mysql_root_password: ...
+mysql_zabbix_password: ...
+mysql_zabbix_monitor_password: ...
+EOF
+```
+
+Then normal targeted runs do not need a repeated `--extra-vars` argument:
+
+```bash
+atlas run infra apply --yes --site kanagawa01 --limit kng01-mgmt-zabbix-01
 ```

--- a/modules/daedalus/ansible.py
+++ b/modules/daedalus/ansible.py
@@ -9,6 +9,7 @@ from .paths import ansible_config_path, ansible_root, inventory_path, playbook_p
 
 class AnsibleRunner:
     def __init__(self, site: str) -> None:
+        self.site = site
         self.ansible_root = ansible_root()
         self.inventory = inventory_path(site)
 
@@ -32,6 +33,7 @@ class AnsibleRunner:
         self._append_limit(cmd, limit)
         self._append_option(cmd, "--tags", tags)
         self._append_option(cmd, "--skip-tags", skip_tags)
+        self._append_operator_extra_vars(cmd)
         self._append_option(cmd, "--extra-vars", extra_vars)
         if check:
             cmd.append("--check")
@@ -83,3 +85,23 @@ class AnsibleRunner:
     def _append_option(cmd: list[str], option: str, value: str | None) -> None:
         if value and value.strip():
             cmd.extend([option, value])
+
+    def _append_operator_extra_vars(self, cmd: list[str]) -> None:
+        vars_path = self._operator_extra_vars_path()
+        if vars_path:
+            cmd.extend(["--extra-vars", f"@{vars_path}"])
+
+    def _operator_extra_vars_path(self) -> Path | None:
+        override = os.environ.get("DAEDALUS_OPERATOR_VARS")
+        if override and override.strip():
+            path = Path(override).expanduser()
+            if not path.is_file():
+                raise RuntimeError(f"Operator vars file not found: {path}")
+            return path
+
+        for suffix in ("yml", "yaml", "json"):
+            path = Path.home() / ".config" / "daedalus" / f"{self.site}.{suffix}"
+            if path.is_file():
+                return path
+
+        return None

--- a/tests/test_ansible_runner.py
+++ b/tests/test_ansible_runner.py
@@ -1,0 +1,92 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from daedalus.ansible import AnsibleRunner
+
+
+class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
+    def capture_playbook_cmd(self, runner: AnsibleRunner, **kwargs) -> list[str]:
+        captured: dict[str, list[str]] = {}
+
+        def fake_run(cmd: list[str]) -> None:
+            captured["cmd"] = cmd
+
+        runner._run = fake_run  # type: ignore[method-assign]
+        runner.playbook("site", **kwargs)
+        return captured["cmd"]
+
+    def test_playbook_uses_site_operator_vars_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            vars_path = Path(home) / ".config" / "daedalus" / "kanagawa01.yml"
+            vars_path.parent.mkdir(parents=True)
+            vars_path.write_text("mysql_root_password: test\n", encoding="utf-8")
+
+            with patch.dict(os.environ, {"HOME": home}, clear=True):
+                cmd = self.capture_playbook_cmd(
+                    AnsibleRunner("kanagawa01"),
+                    limit="kng01-mgmt-zabbix-01",
+                    check=True,
+                )
+
+        self.assertIn("--extra-vars", cmd)
+        self.assertIn(f"@{vars_path}", cmd)
+        self.assertLess(cmd.index(f"@{vars_path}"), cmd.index("--check"))
+
+    def test_explicit_extra_vars_follow_operator_vars(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            vars_path = Path(home) / ".config" / "daedalus" / "kanagawa01.yml"
+            vars_path.parent.mkdir(parents=True)
+            vars_path.write_text("mysql_root_password: test\n", encoding="utf-8")
+
+            with patch.dict(os.environ, {"HOME": home}, clear=True):
+                cmd = self.capture_playbook_cmd(
+                    AnsibleRunner("kanagawa01"),
+                    extra_vars="zabbix_agent_enabled=true",
+                )
+
+        extra_vars_indexes = [
+            index for index, value in enumerate(cmd) if value == "--extra-vars"
+        ]
+        self.assertEqual(len(extra_vars_indexes), 2)
+        self.assertEqual(cmd[extra_vars_indexes[0] + 1], f"@{vars_path}")
+        self.assertEqual(cmd[extra_vars_indexes[1] + 1], "zabbix_agent_enabled=true")
+
+    def test_environment_override_takes_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as home:
+            default_path = Path(home) / ".config" / "daedalus" / "kanagawa01.yml"
+            default_path.parent.mkdir(parents=True)
+            default_path.write_text("mysql_root_password: default\n", encoding="utf-8")
+
+            override_path = Path(home) / "operator.yml"
+            override_path.write_text("mysql_root_password: override\n", encoding="utf-8")
+
+            with patch.dict(
+                os.environ,
+                {"HOME": home, "DAEDALUS_OPERATOR_VARS": str(override_path)},
+                clear=True,
+            ):
+                cmd = self.capture_playbook_cmd(AnsibleRunner("kanagawa01"))
+
+        self.assertIn(f"@{override_path}", cmd)
+        self.assertNotIn(f"@{default_path}", cmd)
+
+    def test_missing_environment_override_fails(self) -> None:
+        missing_path = "/tmp/daedalus-missing-vars.yml"
+
+        with patch.dict(
+            os.environ,
+            {"DAEDALUS_OPERATOR_VARS": missing_path},
+            clear=True,
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                f"Operator vars file not found: {missing_path}",
+            ):
+                AnsibleRunner("kanagawa01").playbook("site")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Auto-load site-local operator vars from `~/.config/daedalus/<site>.yml`, `.yaml`, or `.json` in the `infra` wrapper.
- Allow `DAEDALUS_OPERATOR_VARS` to point a run at a different operator vars file.
- Keep explicit `--extra-vars` support after the auto-loaded file so one-off overrides still work.
- Document the default KANAGAWA01 operator vars path and Zabbix secret setup.

## Commit split

- `feat(cli): load operator vars automatically`
- `docs(ops): document operator vars autoload`

## Validation

- `PYTHONPATH=modules python -m unittest discover -s tests`
- `git diff --check HEAD~2..HEAD`
- `ANSIBLE_COLLECTIONS_PATH="$PWD/collections:$tmpdir" uv run --with ansible-core ansible-playbook --syntax-check playbooks/site.yml`