### PR TITLE
[codex] Install missing Ansible collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,11 @@ Runtime dependencies are in `requirements.txt`. Development-only tools are in
 
 ## Direct Ansible Execution
 
-Prefer `infra` for normal operator runs. If you need to bypass the wrapper while
-debugging Ansible itself, execute from `ansible/` or set the config explicitly:
+Prefer `infra` for normal operator runs. The wrapper installs missing Ansible
+collections from `ansible/collections/requirements.yml` before playbook runs.
+
+If you need to bypass the wrapper while debugging Ansible itself, execute from
+`ansible/` or set the config explicitly:
 
 ```bash
 cd ansible

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,6 +11,10 @@ atlas run infra apply --yes --site kanagawa01 --limit svc_dns_recursive
 Use `infra sites` and `infra playbooks` before targeting a non-default site or
 public playbook entrypoint.
 
+The `infra` wrapper installs missing Ansible collections from
+`ansible/collections/requirements.yml` before playbook runs, so normal Atlas
+runs do not need a separate `ansible-galaxy collection install` step.
+
 Normal steady-state runs should use the default `site` playbook and narrow the
 target with `--limit <inventory-group-or-host>` when needed. Reserve
 `--playbook bootstrap` for first converge on a newly added Atlas-managed host.

--- a/modules/daedalus/ansible.py
+++ b/modules/daedalus/ansible.py
@@ -4,7 +4,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+import yaml
+
 from .paths import ansible_config_path, ansible_root, inventory_path, playbook_path
+
+
+GALAXY_INSTALL_TIMEOUT_SECONDS = 120
+GALAXY_SERVER_TIMEOUT_SECONDS = 30
 
 
 class AnsibleRunner:
@@ -40,7 +46,7 @@ class AnsibleRunner:
         if diff:
             cmd.append("--diff")
 
-        self._run(cmd)
+        self._run(cmd, ensure_collections=True)
 
     def adhoc(self, module: str, limit: str | None = None) -> None:
         cmd = [
@@ -64,11 +70,14 @@ class AnsibleRunner:
         ]
         self._run(cmd)
 
-    def _run(self, cmd: list[str]) -> None:
+    def _run(self, cmd: list[str], ensure_collections: bool = False) -> None:
         env = os.environ.copy()
         env["ANSIBLE_CONFIG"] = str(ansible_config_path())
         executable_dir = str(Path(sys.executable).parent)
         env["PATH"] = os.pathsep.join([executable_dir, env.get("PATH", "")])
+
+        if ensure_collections:
+            self._ensure_collections(env)
 
         print(f"Running: {shlex.join(cmd)}", flush=True)
         subprocess.run(cmd, check=True, cwd=self.ansible_root, env=env)
@@ -105,3 +114,84 @@ class AnsibleRunner:
                 return path
 
         return None
+
+    def _ensure_collections(self, env: dict[str, str]) -> None:
+        if not self._missing_collections():
+            return
+
+        requirements = self._collections_requirements_path()
+        cmd = [
+            "ansible-galaxy",
+            "collection",
+            "install",
+            "--timeout",
+            str(GALAXY_SERVER_TIMEOUT_SECONDS),
+            "-r",
+            self._relative(requirements),
+            "-p",
+            self._relative(self._collections_path()),
+        ]
+        print(f"Running: {shlex.join(cmd)}", flush=True)
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                cwd=self.ansible_root,
+                env=env,
+                timeout=GALAXY_INSTALL_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                "Timed out installing Ansible collections from "
+                f"{self._relative(requirements)}"
+            ) from exc
+
+    def _missing_collections(self) -> list[str]:
+        return [
+            collection
+            for collection in self._required_collections()
+            if not self._collection_installed(collection)
+        ]
+
+    def _required_collections(self) -> list[str]:
+        requirements = self._collections_requirements_path()
+        if not requirements.is_file():
+            return []
+
+        data = yaml.safe_load(requirements.read_text(encoding="utf-8")) or {}
+        collections = data.get("collections") if isinstance(data, dict) else None
+        if not isinstance(collections, list):
+            return []
+
+        required = []
+        for collection in collections:
+            if isinstance(collection, str):
+                name = collection
+            elif isinstance(collection, dict):
+                name = collection.get("name")
+            else:
+                continue
+
+            if isinstance(name, str) and name.strip():
+                required.append(name.strip())
+
+        return required
+
+    def _collection_installed(self, name: str) -> bool:
+        parts = name.split(".", maxsplit=1)
+        if len(parts) != 2:
+            return False
+
+        namespace, collection = parts
+        return (
+            self._collections_path()
+            / "ansible_collections"
+            / namespace
+            / collection
+        ).is_dir()
+
+    def _collections_path(self) -> Path:
+        return self.ansible_root / "collections"
+
+    def _collections_requirements_path(self) -> Path:
+        return self._collections_path() / "requirements.yml"

--- a/tests/test_ansible_runner.py
+++ b/tests/test_ansible_runner.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,7 +12,7 @@ class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
     def capture_playbook_cmd(self, runner: AnsibleRunner, **kwargs) -> list[str]:
         captured: dict[str, list[str]] = {}
 
-        def fake_run(cmd: list[str]) -> None:
+        def fake_run(cmd: list[str], ensure_collections: bool = False) -> None:
             captured["cmd"] = cmd
 
         runner._run = fake_run  # type: ignore[method-assign]
@@ -86,6 +87,139 @@ class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
                 f"Operator vars file not found: {missing_path}",
             ):
                 AnsibleRunner("kanagawa01").playbook("site")
+
+
+class AnsibleRunnerCollectionsTest(unittest.TestCase):
+    def build_runner(self, ansible_root: Path) -> AnsibleRunner:
+        runner = AnsibleRunner("kanagawa01")
+        runner.ansible_root = ansible_root
+        return runner
+
+    def write_requirements(self, ansible_root: Path) -> None:
+        collections = ansible_root / "collections"
+        collections.mkdir(parents=True)
+        (collections / "requirements.yml").write_text(
+            "---\ncollections:\n  - name: community.mysql\n",
+            encoding="utf-8",
+        )
+
+    def install_collection(self, ansible_root: Path) -> None:
+        (
+            ansible_root
+            / "collections"
+            / "ansible_collections"
+            / "community"
+            / "mysql"
+        ).mkdir(parents=True)
+
+    def test_playbook_enables_collection_check(self) -> None:
+        runner = AnsibleRunner("kanagawa01")
+
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(runner, "_run") as run,
+        ):
+            runner.playbook("site")
+
+        run.assert_called_once()
+        self.assertTrue(run.call_args.kwargs["ensure_collections"])
+
+    def test_inventory_graph_skips_collection_check(self) -> None:
+        runner = AnsibleRunner("kanagawa01")
+
+        with patch.object(runner, "_run") as run:
+            runner.inventory_graph()
+
+        run.assert_called_once()
+        self.assertEqual(run.call_args.kwargs, {})
+
+    def test_missing_collection_is_detected_from_requirements(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            ansible_root = Path(tempdir)
+            self.write_requirements(ansible_root)
+
+            runner = self.build_runner(ansible_root)
+
+            self.assertEqual(runner._missing_collections(), ["community.mysql"])
+
+    def test_installed_collection_is_not_reported_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            ansible_root = Path(tempdir)
+            self.write_requirements(ansible_root)
+            self.install_collection(ansible_root)
+
+            runner = self.build_runner(ansible_root)
+
+            self.assertEqual(runner._missing_collections(), [])
+
+    def test_missing_collection_installs_requirements_before_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            ansible_root = Path(tempdir)
+            self.write_requirements(ansible_root)
+
+            runner = self.build_runner(ansible_root)
+            env = {"ANSIBLE_CONFIG": str(ansible_root / "ansible.cfg")}
+
+            with (
+                patch("builtins.print"),
+                patch("daedalus.ansible.subprocess.run") as run,
+            ):
+                runner._ensure_collections(env)
+
+        run.assert_called_once_with(
+            [
+                "ansible-galaxy",
+                "collection",
+                "install",
+                "--timeout",
+                "30",
+                "-r",
+                "collections/requirements.yml",
+                "-p",
+                "collections",
+            ],
+            check=True,
+            cwd=ansible_root,
+            env=env,
+            timeout=120,
+        )
+
+    def test_collection_install_timeout_reports_runtime_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            ansible_root = Path(tempdir)
+            self.write_requirements(ansible_root)
+
+            runner = self.build_runner(ansible_root)
+
+            with (
+                patch("builtins.print"),
+                patch(
+                    "daedalus.ansible.subprocess.run",
+                    side_effect=subprocess.TimeoutExpired(
+                        cmd="ansible-galaxy",
+                        timeout=120,
+                    ),
+                ),
+            ):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Timed out installing Ansible collections from "
+                    "collections/requirements.yml",
+                ):
+                    runner._ensure_collections({})
+
+    def test_installed_collection_skips_requirements_install(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            ansible_root = Path(tempdir)
+            self.write_requirements(ansible_root)
+            self.install_collection(ansible_root)
+
+            runner = self.build_runner(ansible_root)
+
+            with patch("daedalus.ansible.subprocess.run") as run:
+                runner._ensure_collections({})
+
+        run.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Install missing Ansible collections from `ansible/collections/requirements.yml` before playbook runs.
- Keep lightweight commands such as `infra inventory` out of collection install.
- Document that normal Atlas playbook runs no longer need a separate `ansible-galaxy collection install` step.

## Root Cause
The Zabbix apply reached the MySQL role, but the Atlas release did not have `community.mysql` installed under `ansible/collections`, so Ansible could not resolve `community.mysql.mysql_user`.

## Validation
- `uv run python -m unittest discover -s tests`
- `git diff --check`