### PR TITLE
[codex] Use modern MySQL auth for Zabbix

### DIFF
--- a/ansible/collections/requirements.yml
+++ b/ansible/collections/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
-  - name: community.mysql
+  - name: ansible.mysql
+    version: ">=3.10.0"

--- a/ansible/roles/middleware/mysql-server/defaults/main.yml
+++ b/ansible/roles/middleware/mysql-server/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+mysql_login_unix_socket: /var/run/mysqld/mysqld.sock

--- a/ansible/roles/middleware/mysql-server/tasks/install.yml
+++ b/ansible/roles/middleware/mysql-server/tasks/install.yml
@@ -5,31 +5,20 @@
       - mysql-server
       - mysql-client
       - python3-pymysql  # Required for Ansible
+      - python3-cryptography  # Required for caching_sha2_password via PyMySQL
       - python3-setuptools  # Required for Ansible
     state: present
-
-- name: Set Root Password
-  community.mysql.mysql_user:
-    login_user: "root"
-    login_password: "{{ mysql_root_password }}"
-    login_unix_socket: "{{ mysql_login_unix_socket }}"
-    name: "root"
-    password: "{{ mysql_root_password }}"
-    check_implicit_admin: true
-    state: present
-  notify: restart mysql
-
-- name: Remove anonymous users
-  community.mysql.mysql_user:
-    login_user: "root"
-    login_password: "{{ mysql_root_password }}"
-    login_unix_socket: "{{ mysql_login_unix_socket }}"
-    name: ""
-    state: absent
-  notify: restart mysql
 
 - name: Start mysql
   ansible.builtin.systemd_service:
     name: mysql
     state: started
     enabled: true
+
+- name: Remove anonymous users
+  ansible.mysql.mysql_user:
+    login_user: "root"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+    name: ""
+    host_all: true
+    state: absent

--- a/ansible/roles/middleware/zabbix-server/defaults/main.yml
+++ b/ansible/roles/middleware/zabbix-server/defaults/main.yml
@@ -47,4 +47,7 @@ mysql_login_unix_socket: /var/run/mysqld/mysqld.sock
 mysql_zabbix_dbname: zabbix
 mysql_zabbix_user: zabbix
 mysql_zabbix_monitor_user: zabbix_monitor
+mysql_zabbix_auth_plugin: caching_sha2_password
+mysql_zabbix_password_salt: daedalus_zabbix_user
+mysql_zabbix_monitor_password_salt: daedalus_zbxmon_user
 zabbix_server_mysql_schema_path: /usr/share/zabbix-sql-scripts/mysql/server.sql.gz

--- a/ansible/roles/middleware/zabbix-server/tasks/mysql.yml
+++ b/ansible/roles/middleware/zabbix-server/tasks/mysql.yml
@@ -9,9 +9,8 @@
   notify: restart mysql
 
 - name: Create Zabbix Database
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     login_user: "root"
-    login_password: "{{ mysql_root_password }}"
     login_unix_socket: "{{ mysql_login_unix_socket }}"
     name: "{{ mysql_zabbix_dbname }}"
     encoding: utf8mb4
@@ -19,31 +18,32 @@
     state: present
 
 - name: Create Zabbix User
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     login_user: "root"
-    login_password: "{{ mysql_root_password }}"
     login_unix_socket: "{{ mysql_login_unix_socket }}"
     name: "{{ mysql_zabbix_user }}"
-    password: "{{ mysql_zabbix_password }}"
     host: "localhost"
+    plugin: "{{ mysql_zabbix_auth_plugin }}"
+    plugin_auth_string: "{{ mysql_zabbix_password }}"
+    salt: "{{ mysql_zabbix_password_salt }}"
     priv: "{{ mysql_zabbix_dbname }}.*:ALL"
     state: present
 
 - name: Create zabbix_monitor User
-  community.mysql.mysql_user:
+  ansible.mysql.mysql_user:
     login_user: "root"
-    login_password: "{{ mysql_root_password }}"
     login_unix_socket: "{{ mysql_login_unix_socket }}"
     name: "{{ mysql_zabbix_monitor_user }}"
-    password: "{{ mysql_zabbix_monitor_password }}"
     host: "127.0.0.1"
+    plugin: "{{ mysql_zabbix_auth_plugin }}"
+    plugin_auth_string: "{{ mysql_zabbix_monitor_password }}"
+    salt: "{{ mysql_zabbix_monitor_password_salt }}"
     priv: "*.*:REPLICATION CLIENT,PROCESS,SHOW DATABASES,SHOW VIEW"
     state: present
 
 - name: Check Zabbix database schema status
-  community.mysql.mysql_query:
+  ansible.mysql.mysql_query:
     login_user: "root"
-    login_password: "{{ mysql_root_password }}"
     login_unix_socket: "{{ mysql_login_unix_socket }}"
     login_db: "{{ mysql_zabbix_dbname }}"
     query: "SHOW TABLES LIKE 'config'"
@@ -72,7 +72,7 @@
     - zabbix_server_schema_status.query_result[0] | length == 0
 
 - name: Import Zabbix initial schema
-  community.mysql.mysql_db:
+  ansible.mysql.mysql_db:
     login_user: "{{ mysql_zabbix_user }}"
     login_password: "{{ mysql_zabbix_password }}"
     login_unix_socket: "{{ mysql_login_unix_socket }}"

--- a/ansible/roles/middleware/zabbix-server/tasks/preflight.yml
+++ b/ansible/roles/middleware/zabbix-server/tasks/preflight.yml
@@ -18,6 +18,5 @@
       before enabling zabbix_server_installation_managed.
     quiet: true
   loop:
-    - mysql_root_password
     - mysql_zabbix_password
     - mysql_zabbix_monitor_password

--- a/docs/components.md
+++ b/docs/components.md
@@ -87,9 +87,10 @@ systemd-resolved policy, `zabbix-agent2`, local MySQL, PHP-FPM, Caddy, and the
 Zabbix server/frontend packages for the host. The managed frontend listens on
 HTTP port 80 through Caddy and serves `zabbix.alflag.internal` via the host's
 normal management-plane address. Apply runs require the database secret vars
-`mysql_root_password`, `mysql_zabbix_password`, and
-`mysql_zabbix_monitor_password` from the operator secret store, the site-local
-operator vars file loaded by `infra`, or operator-provided extra vars. The VM is
+`mysql_zabbix_password` and `mysql_zabbix_monitor_password` from the operator
+secret store, the site-local operator vars file loaded by `infra`, or
+operator-provided extra vars. The local MySQL root account is managed over the
+Unix socket and does not need an operator-provided database password. The VM is
 expected to exist before Daedalus runs; Daedalus manages the guest configuration
 after it is reachable at `10.10.10.250`.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -45,10 +45,12 @@ auto-loaded file.
 For the managed Zabbix server, apply runs require these database variables:
 
 ```yaml
-mysql_root_password: ...
 mysql_zabbix_password: ...
 mysql_zabbix_monitor_password: ...
 ```
+
+The local MySQL root account is managed over the Unix socket and does not need
+an operator-provided database password.
 
 Store them in the KANAGAWA01 operator vars file:
 
@@ -56,7 +58,6 @@ Store them in the KANAGAWA01 operator vars file:
 mkdir -p /home/ops/.config/daedalus
 umask 077
 cat > /home/ops/.config/daedalus/kanagawa01.yml <<'EOF'
-mysql_root_password: ...
 mysql_zabbix_password: ...
 mysql_zabbix_monitor_password: ...
 EOF

--- a/modules/daedalus/ansible.py
+++ b/modules/daedalus/ansible.py
@@ -1,7 +1,10 @@
+import json
 import os
+import re
 import shlex
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -11,6 +14,12 @@ from .paths import ansible_config_path, ansible_root, inventory_path, playbook_p
 
 GALAXY_INSTALL_TIMEOUT_SECONDS = 120
 GALAXY_SERVER_TIMEOUT_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class CollectionRequirement:
+    name: str
+    version: str | None = None
 
 
 class AnsibleRunner:
@@ -126,6 +135,7 @@ class AnsibleRunner:
             "install",
             "--timeout",
             str(GALAXY_SERVER_TIMEOUT_SECONDS),
+            "--upgrade",
             "-r",
             self._relative(requirements),
             "-p",
@@ -148,12 +158,12 @@ class AnsibleRunner:
 
     def _missing_collections(self) -> list[str]:
         return [
-            collection
-            for collection in self._required_collections()
-            if not self._collection_installed(collection)
+            requirement.name
+            for requirement in self._required_collections()
+            if not self._collection_satisfies(requirement)
         ]
 
-    def _required_collections(self) -> list[str]:
+    def _required_collections(self) -> list[CollectionRequirement]:
         requirements = self._collections_requirements_path()
         if not requirements.is_file():
             return []
@@ -167,20 +177,42 @@ class AnsibleRunner:
         for collection in collections:
             if isinstance(collection, str):
                 name = collection
+                version = None
             elif isinstance(collection, dict):
                 name = collection.get("name")
+                version = collection.get("version")
             else:
                 continue
 
             if isinstance(name, str) and name.strip():
-                required.append(name.strip())
+                required.append(
+                    CollectionRequirement(
+                        name=name.strip(),
+                        version=version.strip()
+                        if isinstance(version, str) and version.strip()
+                        else None,
+                    )
+                )
 
         return required
 
-    def _collection_installed(self, name: str) -> bool:
+    def _collection_satisfies(self, requirement: CollectionRequirement) -> bool:
+        collection_path = self._collection_install_path(requirement.name)
+        if not collection_path.is_dir():
+            return False
+        if not requirement.version:
+            return True
+
+        installed_version = self._installed_collection_version(collection_path)
+        if not installed_version:
+            return False
+
+        return self._version_satisfies(installed_version, requirement.version)
+
+    def _collection_install_path(self, name: str) -> Path:
         parts = name.split(".", maxsplit=1)
         if len(parts) != 2:
-            return False
+            return self._collections_path() / "ansible_collections" / name
 
         namespace, collection = parts
         return (
@@ -188,7 +220,70 @@ class AnsibleRunner:
             / "ansible_collections"
             / namespace
             / collection
-        ).is_dir()
+        )
+
+    @staticmethod
+    def _installed_collection_version(collection_path: Path) -> str | None:
+        manifest = collection_path / "MANIFEST.json"
+        if not manifest.is_file():
+            return None
+
+        try:
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return None
+        collection_info = data.get("collection_info")
+        if not isinstance(collection_info, dict):
+            return None
+
+        version = collection_info.get("version")
+        return version if isinstance(version, str) else None
+
+    @classmethod
+    def _version_satisfies(cls, installed: str, requirement: str) -> bool:
+        clauses = [clause.strip() for clause in requirement.split(",") if clause.strip()]
+        return all(cls._version_clause_satisfies(installed, clause) for clause in clauses)
+
+    @classmethod
+    def _version_clause_satisfies(cls, installed: str, clause: str) -> bool:
+        match = re.fullmatch(r"(<=|>=|==|!=|<|>|=)?\s*([0-9][0-9A-Za-z.+-]*)", clause)
+        if not match:
+            return False
+
+        operator = match.group(1) or "=="
+        required = match.group(2)
+        installed_parts = cls._version_parts(installed)
+        required_parts = cls._version_parts(required)
+        if installed_parts is None or required_parts is None:
+            return False
+
+        if operator in ("=", "=="):
+            return installed_parts == required_parts
+        if operator == "!=":
+            return installed_parts != required_parts
+        if operator == ">=":
+            return installed_parts >= required_parts
+        if operator == ">":
+            return installed_parts > required_parts
+        if operator == "<=":
+            return installed_parts <= required_parts
+        if operator == "<":
+            return installed_parts < required_parts
+        return False
+
+    @staticmethod
+    def _version_parts(value: str) -> tuple[int, ...] | None:
+        parts = []
+        for part in value.split("."):
+            match = re.match(r"\d+", part)
+            if not match:
+                return None
+            parts.append(int(match.group(0)))
+
+        while len(parts) < 3:
+            parts.append(0)
+
+        return tuple(parts)
 
     def _collections_path(self) -> Path:
         return self.ansible_root / "collections"

--- a/tests/test_ansible_runner.py
+++ b/tests/test_ansible_runner.py
@@ -23,7 +23,7 @@ class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as home:
             vars_path = Path(home) / ".config" / "daedalus" / "kanagawa01.yml"
             vars_path.parent.mkdir(parents=True)
-            vars_path.write_text("mysql_root_password: test\n", encoding="utf-8")
+            vars_path.write_text("mysql_zabbix_password: test\n", encoding="utf-8")
 
             with patch.dict(os.environ, {"HOME": home}, clear=True):
                 cmd = self.capture_playbook_cmd(
@@ -40,7 +40,7 @@ class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as home:
             vars_path = Path(home) / ".config" / "daedalus" / "kanagawa01.yml"
             vars_path.parent.mkdir(parents=True)
-            vars_path.write_text("mysql_root_password: test\n", encoding="utf-8")
+            vars_path.write_text("mysql_zabbix_password: test\n", encoding="utf-8")
 
             with patch.dict(os.environ, {"HOME": home}, clear=True):
                 cmd = self.capture_playbook_cmd(
@@ -59,10 +59,10 @@ class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as home:
             default_path = Path(home) / ".config" / "daedalus" / "kanagawa01.yml"
             default_path.parent.mkdir(parents=True)
-            default_path.write_text("mysql_root_password: default\n", encoding="utf-8")
+            default_path.write_text("mysql_zabbix_password: default\n", encoding="utf-8")
 
             override_path = Path(home) / "operator.yml"
-            override_path.write_text("mysql_root_password: override\n", encoding="utf-8")
+            override_path.write_text("mysql_zabbix_password: override\n", encoding="utf-8")
 
             with patch.dict(
                 os.environ,
@@ -99,18 +99,23 @@ class AnsibleRunnerCollectionsTest(unittest.TestCase):
         collections = ansible_root / "collections"
         collections.mkdir(parents=True)
         (collections / "requirements.yml").write_text(
-            "---\ncollections:\n  - name: community.mysql\n",
+            "---\ncollections:\n  - name: ansible.mysql\n    version: '>=3.10.0'\n",
             encoding="utf-8",
         )
 
-    def install_collection(self, ansible_root: Path) -> None:
-        (
+    def install_collection(self, ansible_root: Path, version: str = "3.10.0") -> None:
+        collection_path = (
             ansible_root
             / "collections"
             / "ansible_collections"
-            / "community"
+            / "ansible"
             / "mysql"
-        ).mkdir(parents=True)
+        )
+        collection_path.mkdir(parents=True)
+        (collection_path / "MANIFEST.json").write_text(
+            f'{{"collection_info": {{"version": "{version}"}}}}\n',
+            encoding="utf-8",
+        )
 
     def test_playbook_enables_collection_check(self) -> None:
         runner = AnsibleRunner("kanagawa01")
@@ -140,7 +145,17 @@ class AnsibleRunnerCollectionsTest(unittest.TestCase):
 
             runner = self.build_runner(ansible_root)
 
-            self.assertEqual(runner._missing_collections(), ["community.mysql"])
+            self.assertEqual(runner._missing_collections(), ["ansible.mysql"])
+
+    def test_outdated_collection_is_reported_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            ansible_root = Path(tempdir)
+            self.write_requirements(ansible_root)
+            self.install_collection(ansible_root, version="3.9.9")
+
+            runner = self.build_runner(ansible_root)
+
+            self.assertEqual(runner._missing_collections(), ["ansible.mysql"])
 
     def test_installed_collection_is_not_reported_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
@@ -173,6 +188,7 @@ class AnsibleRunnerCollectionsTest(unittest.TestCase):
                 "install",
                 "--timeout",
                 "30",
+                "--upgrade",
                 "-r",
                 "collections/requirements.yml",
                 "-p",

--- a/tests/test_zabbix_mysql_roles.py
+++ b/tests/test_zabbix_mysql_roles.py
@@ -1,0 +1,87 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_yaml(path: str):
+    return yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8"))
+
+
+class ZabbixMysqlRolesTest(unittest.TestCase):
+    def test_collection_requirement_uses_ansible_mysql(self) -> None:
+        requirements = load_yaml("ansible/collections/requirements.yml")
+
+        self.assertEqual(
+            requirements["collections"],
+            [{"name": "ansible.mysql", "version": ">=3.10.0"}],
+        )
+
+    def test_mysql_server_uses_socket_root_management(self) -> None:
+        tasks = load_yaml("ansible/roles/middleware/mysql-server/tasks/install.yml")
+        by_name = {task["name"]: task for task in tasks}
+
+        self.assertNotIn("Set Root Password", by_name)
+        self.assertIn(
+            "python3-cryptography",
+            by_name["Install mysql-server"]["ansible.builtin.apt"]["name"],
+        )
+
+        anonymous_user = by_name["Remove anonymous users"]["ansible.mysql.mysql_user"]
+        self.assertEqual(anonymous_user["login_user"], "root")
+        self.assertEqual(
+            anonymous_user["login_unix_socket"],
+            "{{ mysql_login_unix_socket }}",
+        )
+        self.assertNotIn("login_password", anonymous_user)
+        self.assertTrue(anonymous_user["host_all"])
+
+    def test_zabbix_mysql_users_use_caching_sha2_password(self) -> None:
+        tasks = load_yaml("ansible/roles/middleware/zabbix-server/tasks/mysql.yml")
+        by_name = {task["name"]: task for task in tasks}
+
+        zabbix_user = by_name["Create Zabbix User"]["ansible.mysql.mysql_user"]
+        monitor_user = by_name["Create zabbix_monitor User"]["ansible.mysql.mysql_user"]
+
+        for user in (zabbix_user, monitor_user):
+            self.assertEqual(user["login_user"], "root")
+            self.assertEqual(user["plugin"], "{{ mysql_zabbix_auth_plugin }}")
+            self.assertNotIn("login_password", user)
+            self.assertNotIn("password", user)
+
+        self.assertEqual(zabbix_user["plugin_auth_string"], "{{ mysql_zabbix_password }}")
+        self.assertEqual(zabbix_user["salt"], "{{ mysql_zabbix_password_salt }}")
+        self.assertEqual(
+            monitor_user["plugin_auth_string"],
+            "{{ mysql_zabbix_monitor_password }}",
+        )
+        self.assertEqual(
+            monitor_user["salt"],
+            "{{ mysql_zabbix_monitor_password_salt }}",
+        )
+
+    def test_zabbix_mysql_defaults_use_valid_auth_salts(self) -> None:
+        defaults = load_yaml("ansible/roles/middleware/zabbix-server/defaults/main.yml")
+
+        self.assertEqual(defaults["mysql_zabbix_auth_plugin"], "caching_sha2_password")
+        self.assertEqual(len(defaults["mysql_zabbix_password_salt"]), 20)
+        self.assertEqual(len(defaults["mysql_zabbix_monitor_password_salt"]), 20)
+
+    def test_preflight_no_longer_requires_mysql_root_password(self) -> None:
+        tasks = load_yaml("ansible/roles/middleware/zabbix-server/tasks/preflight.yml")
+        secret_check = {
+            task["name"]: task
+            for task in tasks
+        }["Validate required Zabbix database secret variables"]
+
+        self.assertEqual(
+            secret_check["loop"],
+            ["mysql_zabbix_password", "mysql_zabbix_monitor_password"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Switch Zabbix MySQL management from deprecated `community.mysql` redirects to `ansible.mysql`.
- Stop managing a local MySQL root password; use root over the Unix socket for local administration.
- Create Zabbix database users with `caching_sha2_password` via `plugin_auth_string` and fixed salts for idempotence.
- Teach the `infra` wrapper to honor collection version requirements and use `--upgrade` when needed.
- Update operator docs so only the Zabbix DB user passwords are required.

## Root Cause
MySQL 8.4 disables `mysql_native_password` by default. The previous `mysql_user` tasks used the `password` parameter, which maps to that legacy plugin and failed with `Plugin 'mysql_native_password' is not loaded`.

## Validation
- `uv run python -m unittest discover -s tests`
- `git diff --check HEAD~4..HEAD`
- `ANSIBLE_COLLECTIONS_PATH=/opt/atlas/tmp/tmp.z9hBMHrK96 uv run ansible-playbook --syntax-check -i inventories/kanagawa01/hosts.yml playbooks/site.yml`
