### PR TITLE
[codex] Add Caddy repository with deb822

### DIFF
--- a/ansible/roles/middleware/caddy/tasks/install.yml
+++ b/ansible/roles/middleware/caddy/tasks/install.yml
@@ -1,18 +1,25 @@
 ---
-- name: Install gnupg
+- name: Install Caddy repository prerequisites
   ansible.builtin.apt:
-    name: gnupg
+    name:
+      - ca-certificates
+      - python3-debian
     state: present
     update_cache: true
 
-- name: Add Caddy repository key
-  ansible.builtin.apt_key:
-    url: "https://dl.cloudsmith.io/public/caddy/stable/gpg.key"
-    keyring: "/usr/share/keyrings/caddy-stable-archive-keyring.gpg"
-
 - name: Add Caddy repository
-  apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main"
+  ansible.builtin.deb822_repository:
+    name: caddy-stable
+    types:
+      - deb
+    uris:
+      - https://dl.cloudsmith.io/public/caddy/stable/deb/debian
+    suites:
+      - any-version
+    components:
+      - main
+    signed_by: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
+    state: present
 
 - name: Install Caddy
   ansible.builtin.apt:

--- a/tests/test_caddy_role.py
+++ b/tests/test_caddy_role.py
@@ -1,0 +1,51 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class CaddyRoleTest(unittest.TestCase):
+    def test_caddy_repository_uses_deb822(self) -> None:
+        tasks = yaml.safe_load(
+            (
+                REPO_ROOT
+                / "ansible"
+                / "roles"
+                / "middleware"
+                / "caddy"
+                / "tasks"
+                / "install.yml"
+            ).read_text(encoding="utf-8")
+        )
+        by_name = {task["name"]: task for task in tasks}
+
+        for task in tasks:
+            self.assertNotIn("ansible.builtin.apt_key", task)
+            self.assertNotIn("apt_repository", task)
+            self.assertNotIn("ansible.builtin.apt_repository", task)
+
+        prerequisites = by_name["Install Caddy repository prerequisites"]
+        self.assertEqual(
+            prerequisites["ansible.builtin.apt"]["name"],
+            ["ca-certificates", "python3-debian"],
+        )
+
+        repository = by_name["Add Caddy repository"]["ansible.builtin.deb822_repository"]
+        self.assertEqual(repository["name"], "caddy-stable")
+        self.assertEqual(
+            repository["uris"],
+            ["https://dl.cloudsmith.io/public/caddy/stable/deb/debian"],
+        )
+        self.assertEqual(repository["suites"], ["any-version"])
+        self.assertEqual(repository["components"], ["main"])
+        self.assertEqual(
+            repository["signed_by"],
+            "https://dl.cloudsmith.io/public/caddy/stable/gpg.key",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace the Caddy role's deprecated `apt_key` / `apt_repository` setup with `deb822_repository`.
- Install `python3-debian` before managing the deb822 source, as required by the module.
- Add a regression test that blocks `apt_key` and legacy repository setup from returning to the Caddy role.

## Root Cause
Ubuntu 26.04 no longer provides the `apt-key` executable. The previous Caddy repository setup used `ansible.builtin.apt_key`, which shells out to `apt-key` and fails before Caddy can be installed.

## Validation
- `uv run python -m unittest discover -s tests`
- `git diff --check HEAD~2..HEAD`
- `ANSIBLE_COLLECTIONS_PATH=/opt/atlas/tmp/tmp.z9hBMHrK96 uv run ansible-playbook --syntax-check -i inventories/kanagawa01/hosts.yml playbooks/site.yml`
