### PR TITLE
[codex] Handle Zabbix schema imports with binary logging

### DIFF
--- a/ansible/roles/middleware/zabbix-server/defaults/main.yml
+++ b/ansible/roles/middleware/zabbix-server/defaults/main.yml
@@ -51,3 +51,5 @@ mysql_zabbix_auth_plugin: caching_sha2_password
 mysql_zabbix_password_salt: daedalus_zabbix_user
 mysql_zabbix_monitor_password_salt: daedalus_zbxmon_user
 zabbix_server_mysql_schema_path: /usr/share/zabbix-sql-scripts/mysql/server.sql.gz
+zabbix_server_mysql_schema_min_trigger_count: 65
+zabbix_server_recreate_partial_schema: false

--- a/ansible/roles/middleware/zabbix-server/tasks/mysql.yml
+++ b/ansible/roles/middleware/zabbix-server/tasks/mysql.yml
@@ -46,9 +46,65 @@
     login_user: "root"
     login_unix_socket: "{{ mysql_login_unix_socket }}"
     login_db: "{{ mysql_zabbix_dbname }}"
-    query: "SHOW TABLES LIKE 'config'"
+    query: >-
+      SELECT
+      (SELECT COUNT(*) FROM information_schema.tables
+      WHERE table_schema = DATABASE()) AS table_count,
+      (SELECT COUNT(*) FROM information_schema.triggers
+      WHERE trigger_schema = DATABASE()) AS trigger_count
   register: zabbix_server_schema_status
   changed_when: false
+  when: not ansible_check_mode
+
+- name: Record Zabbix database schema status
+  ansible.builtin.set_fact:
+    zabbix_server_schema_table_count: >-
+      {{ zabbix_server_schema_status.query_result[0][0].table_count | int }}
+    zabbix_server_schema_trigger_count: >-
+      {{ zabbix_server_schema_status.query_result[0][0].trigger_count | int }}
+  when: not ansible_check_mode
+
+- name: Reset partial Zabbix database schema when explicitly requested
+  block:
+    - name: Drop partial Zabbix database schema
+      ansible.mysql.mysql_db:
+        login_user: "root"
+        login_unix_socket: "{{ mysql_login_unix_socket }}"
+        name: "{{ mysql_zabbix_dbname }}"
+        state: absent
+
+    - name: Recreate Zabbix database after partial schema reset
+      ansible.mysql.mysql_db:
+        login_user: "root"
+        login_unix_socket: "{{ mysql_login_unix_socket }}"
+        name: "{{ mysql_zabbix_dbname }}"
+        encoding: utf8mb4
+        collation: utf8mb4_bin
+        state: present
+
+    - name: Mark Zabbix database schema as empty after reset
+      ansible.builtin.set_fact:
+        zabbix_server_schema_table_count: 0
+        zabbix_server_schema_trigger_count: 0
+  when:
+    - not ansible_check_mode
+    - zabbix_server_schema_table_count | int > 0
+    - zabbix_server_schema_trigger_count | int < zabbix_server_mysql_schema_min_trigger_count | int
+    - zabbix_server_recreate_partial_schema | bool
+
+- name: Validate Zabbix database schema is empty or complete
+  ansible.builtin.assert:
+    that:
+      - >-
+        zabbix_server_schema_table_count | int == 0 or
+        zabbix_server_schema_trigger_count | int >=
+        zabbix_server_mysql_schema_min_trigger_count | int
+    fail_msg: >-
+      Zabbix database {{ mysql_zabbix_dbname }} contains a partial schema
+      import: {{ zabbix_server_schema_table_count }} table(s) and
+      {{ zabbix_server_schema_trigger_count }} trigger(s) were found. Recreate
+      the database deliberately, or set zabbix_server_recreate_partial_schema=true
+      for this fresh provisioning run.
   when: not ansible_check_mode
 
 - name: Check Zabbix initial schema file
@@ -57,7 +113,7 @@
   register: zabbix_server_mysql_schema_file
   when:
     - not ansible_check_mode
-    - zabbix_server_schema_status.query_result[0] | length == 0
+    - zabbix_server_schema_table_count | int == 0
 
 - name: Validate Zabbix initial schema file exists
   ansible.builtin.assert:
@@ -69,17 +125,63 @@
       configured Zabbix repository.
   when:
     - not ansible_check_mode
-    - zabbix_server_schema_status.query_result[0] | length == 0
+    - zabbix_server_schema_table_count | int == 0
 
 - name: Import Zabbix initial schema
-  ansible.mysql.mysql_db:
-    login_user: "{{ mysql_zabbix_user }}"
-    login_password: "{{ mysql_zabbix_password }}"
-    login_unix_socket: "{{ mysql_login_unix_socket }}"
-    name: "{{ mysql_zabbix_dbname }}"
-    state: import
-    target: "{{ zabbix_server_mysql_schema_path }}"
-    use_shell: true
+  block:
+    - name: Enable trusted function creators for Zabbix schema import
+      ansible.mysql.mysql_query:
+        login_user: "root"
+        login_unix_socket: "{{ mysql_login_unix_socket }}"
+        query: "SET GLOBAL log_bin_trust_function_creators = 1"
+      changed_when: true
+
+    - name: Import Zabbix initial schema
+      ansible.mysql.mysql_db:
+        login_user: "{{ mysql_zabbix_user }}"
+        login_password: "{{ mysql_zabbix_password }}"
+        login_unix_socket: "{{ mysql_login_unix_socket }}"
+        name: "{{ mysql_zabbix_dbname }}"
+        state: import
+        target: "{{ zabbix_server_mysql_schema_path }}"
+        use_shell: true
+  always:
+    - name: Disable trusted function creators after Zabbix schema import
+      ansible.mysql.mysql_query:
+        login_user: "root"
+        login_unix_socket: "{{ mysql_login_unix_socket }}"
+        query: "SET GLOBAL log_bin_trust_function_creators = 0"
+      changed_when: true
   when:
     - not ansible_check_mode
-    - zabbix_server_schema_status.query_result[0] | length == 0
+    - zabbix_server_schema_table_count | int == 0
+
+- name: Check imported Zabbix schema trigger status
+  ansible.mysql.mysql_query:
+    login_user: "root"
+    login_unix_socket: "{{ mysql_login_unix_socket }}"
+    login_db: "{{ mysql_zabbix_dbname }}"
+    query: >-
+      SELECT COUNT(*) AS trigger_count
+      FROM information_schema.triggers
+      WHERE trigger_schema = DATABASE()
+  register: zabbix_server_imported_schema_status
+  changed_when: false
+  when:
+    - not ansible_check_mode
+    - zabbix_server_schema_table_count | int == 0
+
+- name: Validate imported Zabbix schema trigger count
+  ansible.builtin.assert:
+    that:
+      - >-
+        zabbix_server_imported_schema_status.query_result[0][0].trigger_count | int >=
+        zabbix_server_mysql_schema_min_trigger_count | int
+    fail_msg: >-
+      Zabbix schema import completed without the expected trigger count.
+      Expected at least {{ zabbix_server_mysql_schema_min_trigger_count }}
+      trigger(s), found
+      {{ zabbix_server_imported_schema_status.query_result[0][0].trigger_count }}.
+  when:
+    - not ansible_check_mode
+    - zabbix_server_schema_table_count | int == 0

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -68,3 +68,12 @@ Then normal targeted runs do not need a repeated `--extra-vars` argument:
 ```bash
 atlas run infra apply --yes --site kanagawa01 --limit kng01-mgmt-zabbix-01
 ```
+
+If the initial Zabbix schema import fails partway through a fresh provisioning
+run, the next apply stops when it detects the partial database instead of
+treating it as complete. For a fresh host where the Zabbix database can be
+discarded, add this one-time operator var and rerun the targeted apply:
+
+```yaml
+zabbix_server_recreate_partial_schema: true
+```

--- a/tests/test_zabbix_mysql_roles.py
+++ b/tests/test_zabbix_mysql_roles.py
@@ -69,6 +69,8 @@ class ZabbixMysqlRolesTest(unittest.TestCase):
         self.assertEqual(defaults["mysql_zabbix_auth_plugin"], "caching_sha2_password")
         self.assertEqual(len(defaults["mysql_zabbix_password_salt"]), 20)
         self.assertEqual(len(defaults["mysql_zabbix_monitor_password_salt"]), 20)
+        self.assertEqual(defaults["zabbix_server_mysql_schema_min_trigger_count"], 65)
+        self.assertFalse(defaults["zabbix_server_recreate_partial_schema"])
 
     def test_preflight_no_longer_requires_mysql_root_password(self) -> None:
         tasks = load_yaml("ansible/roles/middleware/zabbix-server/tasks/preflight.yml")
@@ -80,6 +82,69 @@ class ZabbixMysqlRolesTest(unittest.TestCase):
         self.assertEqual(
             secret_check["loop"],
             ["mysql_zabbix_password", "mysql_zabbix_monitor_password"],
+        )
+
+    def test_zabbix_schema_status_checks_triggers(self) -> None:
+        tasks = load_yaml("ansible/roles/middleware/zabbix-server/tasks/mysql.yml")
+        schema_status = {
+            task["name"]: task
+            for task in tasks
+        }["Check Zabbix database schema status"]["ansible.mysql.mysql_query"]
+
+        self.assertIn("information_schema.tables", schema_status["query"])
+        self.assertIn("information_schema.triggers", schema_status["query"])
+        self.assertIn("trigger_count", schema_status["query"])
+
+    def test_partial_zabbix_schema_requires_explicit_reset(self) -> None:
+        tasks = load_yaml("ansible/roles/middleware/zabbix-server/tasks/mysql.yml")
+        by_name = {task["name"]: task for task in tasks}
+
+        reset = by_name["Reset partial Zabbix database schema when explicitly requested"]
+        self.assertIn("zabbix_server_recreate_partial_schema | bool", reset["when"])
+
+        validation = by_name["Validate Zabbix database schema is empty or complete"]
+        self.assertIn("ansible.builtin.assert", validation)
+        self.assertIn(
+            "zabbix_server_mysql_schema_min_trigger_count",
+            validation["ansible.builtin.assert"]["that"][0],
+        )
+
+    def test_schema_import_temporarily_trusts_function_creators(self) -> None:
+        tasks = load_yaml("ansible/roles/middleware/zabbix-server/tasks/mysql.yml")
+        import_block = {
+            task["name"]: task
+            for task in tasks
+        }["Import Zabbix initial schema"]
+
+        enable = import_block["block"][0]["ansible.mysql.mysql_query"]
+        disable = import_block["always"][0]["ansible.mysql.mysql_query"]
+        schema_import = import_block["block"][1]["ansible.mysql.mysql_db"]
+
+        self.assertEqual(
+            enable["query"],
+            "SET GLOBAL log_bin_trust_function_creators = 1",
+        )
+        self.assertEqual(
+            disable["query"],
+            "SET GLOBAL log_bin_trust_function_creators = 0",
+        )
+        self.assertEqual(schema_import["state"], "import")
+        self.assertEqual(schema_import["target"], "{{ zabbix_server_mysql_schema_path }}")
+
+    def test_schema_import_validates_trigger_count(self) -> None:
+        tasks = load_yaml("ansible/roles/middleware/zabbix-server/tasks/mysql.yml")
+        by_name = {task["name"]: task for task in tasks}
+
+        trigger_status = by_name["Check imported Zabbix schema trigger status"]
+        self.assertIn(
+            "information_schema.triggers",
+            trigger_status["ansible.mysql.mysql_query"]["query"],
+        )
+
+        validation = by_name["Validate imported Zabbix schema trigger count"]
+        self.assertIn(
+            "zabbix_server_mysql_schema_min_trigger_count",
+            validation["ansible.builtin.assert"]["that"][0],
         )
 
 


### PR DESCRIPTION
## Summary
- Temporarily enable `log_bin_trust_function_creators` while importing the initial Zabbix MySQL schema.
- Validate the imported schema by checking the expected trigger count.
- Detect partial Zabbix schema imports and require an explicit reset flag before recreating the database.
- Document the one-time reset flag for fresh provisioning retries.

## Root Cause
Zabbix 7.0's MySQL schema creates triggers. When MySQL binary logging is enabled, importing those triggers as the Zabbix database user fails unless `GLOBAL log_bin_trust_function_creators = 1` is set for the import. Zabbix documents this requirement for MySQL/MariaDB schema imports with binary logging enabled.

## Validation
- `uv run python -m unittest discover -s tests`
- `git diff --check HEAD~3..HEAD`
- `ANSIBLE_COLLECTIONS_PATH=/opt/atlas/tmp/tmp.z9hBMHrK96 uv run ansible-playbook --syntax-check -i inventories/kanagawa01/hosts.yml playbooks/site.yml`

## Operational Note
If a previous apply already left a partial Zabbix database behind, rerun once with `zabbix_server_recreate_partial_schema: true` in the operator vars for this fresh host.
