### PR TITLE
[codex] Avoid SSH agent auth for infra key

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ private_key_file = ~/.ssh/infra
 remote_user = ops
 host_key_checking = False
 pipelining = True
-ssh_args = -o ForwardAgent=yes
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=no -o IdentitiesOnly=yes -o IdentityAgent=none
 ```
 
 The steady-state connection model is `ops` plus `become`. Hosts bootstrap

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -18,4 +18,4 @@ become_user = root
 pipelining = True
 
 [ssh_connection]
-ssh_args = -o ForwardAgent=yes
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=no -o IdentitiesOnly=yes -o IdentityAgent=none


### PR DESCRIPTION
## Summary
- Stop forwarding the local SSH agent during Ansible runs.
- Force SSH to use the configured `~/.ssh/infra` identity directly with `IdentitiesOnly=yes` and `IdentityAgent=none`.
- Restore Ansible's default SSH multiplexing options while keeping the explicit infra-key behavior.

## Why
A targeted Zabbix apply reached the host after the host-key issue was fixed, then failed mid-play when SSH tried to sign with the local agent:

```text
sign_and_send_pubkey: signing failed for ED25519 "/home/ops/.ssh/infra" from agent: agent refused operation
ops@10.10.10.250: Permission denied (publickey).
```

Atlas runs should not depend on an interactive or forwarded agent when `private_key_file = ~/.ssh/infra` is already configured.

## Validation
- `ANSIBLE_CONFIG=ansible.cfg ../.venv/bin/ansible-playbook -i inventories/kanagawa01/hosts.yml playbooks/components/services/zabbix.yml --syntax-check --extra-vars 'mysql_zabbix_password=dummy mysql_zabbix_monitor_password=dummy'`
- `git diff --check origin/master..HEAD`

## Notes
- I could not run the targeted remote converge from this local environment because this machine does not have the controller's `/home/ops/.ssh/infra` private key.