### PR TITLE
[codex] Fix shared MySQL service alias

### DIFF
--- a/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-mysql-shared-01.yml
+++ b/ansible/inventories/kanagawa01/host_vars/kng01-mgmt-mysql-shared-01.yml
@@ -3,6 +3,7 @@ hostname: kng01-mgmt-mysql-shared-01
 site: kng01
 zone: mgmt
 role: mysql
+purpose: shared
 virtualization_type: vm
 os_distribution: Ubuntu
 os_version: "26.04"
@@ -16,7 +17,7 @@ network_dns_resolvers:
   - 10.10.10.241
 network_primary_fqdn: kng01-mgmt-mysql-shared-01.srv.alflag.internal
 network_service_aliases:
-  - mysql.alflag.internal
+  - mysql-shared.srv.alflag.internal
 
 systemd_resolved_dns:
   - 10.10.10.240

--- a/docs/components.md
+++ b/docs/components.md
@@ -140,7 +140,7 @@ these records in the authoritative internal DNS system:
 | `kng01-mgmt-zabbix-01.srv.alflag.internal` | A | `10.10.10.250` |
 | `zabbix.alflag.internal` | CNAME | `kng01-mgmt-zabbix-01.srv.alflag.internal` |
 | `kng01-mgmt-mysql-shared-01.srv.alflag.internal` | A | `10.10.10.221` |
-| `mysql.alflag.internal` | CNAME | `kng01-mgmt-mysql-shared-01.srv.alflag.internal` |
+| `mysql-shared.srv.alflag.internal` | CNAME | `kng01-mgmt-mysql-shared-01.srv.alflag.internal` |
 
 ## External State
 

--- a/tests/test_zabbix_mysql_roles.py
+++ b/tests/test_zabbix_mysql_roles.py
@@ -237,6 +237,39 @@ class ZabbixMysqlRolesTest(unittest.TestCase):
         host_vars = load_yaml(str(host_vars_path.relative_to(REPO_ROOT)))
         self.assertEqual(host_vars["hostname"], "kng01-mgmt-mysql-shared-01")
 
+    def test_mysql_shared_host_vars_match_inventory(self) -> None:
+        host_vars_path = (
+            REPO_ROOT
+            / "ansible/inventories/kanagawa01/host_vars/kng01-mgmt-mysql-shared-01.yml"
+        )
+        host_vars = load_yaml(str(host_vars_path.relative_to(REPO_ROOT)))
+
+        self.assertEqual(host_vars_path.stem, host_vars["hostname"])
+        self.assertEqual(host_vars["hostname"], "kng01-mgmt-mysql-shared-01")
+        self.assertEqual(host_vars["purpose"], "shared")
+        self.assertEqual(host_vars["network_ipv4_address"], "10.10.10.221")
+        self.assertEqual(host_vars["network_address"], "10.10.10.221/24")
+        self.assertEqual(
+            host_vars["network_primary_fqdn"],
+            "kng01-mgmt-mysql-shared-01.srv.alflag.internal",
+        )
+        self.assertIn(
+            "mysql-shared.srv.alflag.internal",
+            host_vars["network_service_aliases"],
+        )
+        self.assertNotIn(
+            "mysql.alflag.internal",
+            host_vars["network_service_aliases"],
+        )
+
+    def test_docs_use_mysql_shared_alias(self) -> None:
+        components = (REPO_ROOT / "docs/components.md").read_text(encoding="utf-8")
+
+        self.assertIn("10.10.10.221", components)
+        self.assertIn("mysql-shared.srv.alflag.internal", components)
+        self.assertNotIn("10.10.10.251", components)
+        self.assertNotIn("mysql.alflag.internal", components)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Replace the broad shared MySQL DNS alias with `mysql-shared.srv.alflag.internal` in inventory and docs.
- Add `purpose: shared` to the shared MySQL host vars.
- Add regression tests for the shared MySQL hostname, address, alias, and docs entries.

## Why

`mysql.alflag.internal` is too broad for the shared data service and would become ambiguous once dedicated MySQL, workload endpoints, or router endpoints are added.

## Validation

- `.venv/bin/python -m pytest`