### PR TITLE
[codex] Reduce apt work during Ansible runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ Focused component playbooks can still be requested explicitly with
 explicit host-side component playbook, but it is not imported into the normal
 `site` converge because apply runs require operator-provided tunnel tokens.
 
+Package upgrades are left to unattended-upgrades. Daedalus checks requested apt
+packages with `dpkg-query` first and only invokes apt when a package is missing
+or a cleanup role needs to purge an installed package. When apt is needed,
+`daedalus_apt_cache_valid_time` defaults to one day so the daily unattended
+upgrade cache refresh normally prevents repeated `apt update` work during
+steady-state runs.
+
 Reachability:
 
 ```bash

--- a/ansible/inventories/default/group_vars/default.yml
+++ b/ansible/inventories/default/group_vars/default.yml
@@ -10,3 +10,8 @@ retired_monitoring_cleanup_enabled: true
 node_exporter_enabled: true
 node_exporter_listen_address: 0.0.0.0
 node_exporter_listen_port: 9100
+
+# Apt package updates are handled by unattended-upgrades. Ansible only invokes
+# apt when a requested package is missing or an explicit purge is needed.
+daedalus_apt_update_cache: true
+daedalus_apt_cache_valid_time: 86400

--- a/ansible/roles/apt_state/tasks/main.yml
+++ b/ansible/roles/apt_state/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Validate apt state request
+  ansible.builtin.assert:
+    that:
+      - daedalus_apt_packages is defined
+      - daedalus_apt_state | default('present') in ['present', 'absent']
+    quiet: true
+
+- name: Check requested apt packages
+  ansible.builtin.command:
+    argv: "{{ ['dpkg-query', '-W', '-f=${binary:Package}\\n'] + daedalus_apt_package_list }}"
+  vars:
+    daedalus_apt_package_list: >-
+      {{ [daedalus_apt_packages] if daedalus_apt_packages is string else daedalus_apt_packages }}
+  register: daedalus_apt_query
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  when: daedalus_apt_package_list | length > 0
+
+- name: Install missing apt packages
+  ansible.builtin.apt:
+    name: "{{ daedalus_apt_package_list }}"
+    state: present
+    update_cache: "{{ daedalus_apt_update_cache | default(true) | bool }}"
+    cache_valid_time: >-
+      {{ 0 if daedalus_apt_force_update_cache | default(false) | bool else daedalus_apt_cache_valid_time | default(86400) }}
+    policy_rc_d: "{{ daedalus_apt_policy_rc_d | default(omit) }}"
+  vars:
+    daedalus_apt_package_list: >-
+      {{ [daedalus_apt_packages] if daedalus_apt_packages is string else daedalus_apt_packages }}
+  become: "{{ daedalus_apt_become | default(true) }}"
+  when:
+    - daedalus_apt_package_list | length > 0
+    - daedalus_apt_state | default('present') == 'present'
+    - daedalus_apt_query.rc | default(1) != 0
+
+- name: Remove installed apt packages
+  ansible.builtin.apt:
+    name: "{{ daedalus_apt_package_list }}"
+    state: absent
+    purge: "{{ daedalus_apt_purge | default(false) | bool }}"
+    autoremove: "{{ daedalus_apt_autoremove | default(false) | bool }}"
+  vars:
+    daedalus_apt_package_list: >-
+      {{ [daedalus_apt_packages] if daedalus_apt_packages is string else daedalus_apt_packages }}
+  become: "{{ daedalus_apt_become | default(true) }}"
+  when:
+    - daedalus_apt_package_list | length > 0
+    - daedalus_apt_state | default('present') == 'absent'
+    - daedalus_apt_query.stdout_lines | default([]) | length > 0

--- a/ansible/roles/atlas_host/tasks/packages.yml
+++ b/ansible/roles/atlas_host/tasks/packages.yml
@@ -1,7 +1,9 @@
 ---
 - name: Install Atlas host packages
-  ansible.builtin.apt:
-    name:
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages:
       - git
       - curl
       - ca-certificates
@@ -27,6 +29,4 @@
       - libxmlsec1-dev
       - libffi-dev
       - liblzma-dev
-    state: present
-    update_cache: true
-  become: "{{ atlas_become_root }}"
+    daedalus_apt_become: "{{ atlas_become_root }}"

--- a/ansible/roles/cloudflared/tasks/main.yml
+++ b/ansible/roles/cloudflared/tasks/main.yml
@@ -15,10 +15,10 @@
     - not ansible_check_mode
 
 - name: Install cloudflared package
-  ansible.builtin.apt:
-    name: "{{ cloudflared_package }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ cloudflared_package }}"
   when:
     - cloudflared_enabled | bool
     - cloudflared_install_method == 'package'

--- a/ansible/roles/components/alertmanager/tasks/main.yml
+++ b/ansible/roles/components/alertmanager/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install Alertmanager
-  ansible.builtin.apt:
-    name: "{{ alertmanager_package }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ alertmanager_package }}"
   when:
     - alertmanager_enabled | bool
     - not ansible_check_mode

--- a/ansible/roles/components/blackbox_exporter/tasks/main.yml
+++ b/ansible/roles/components/blackbox_exporter/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install blackbox exporter
-  ansible.builtin.apt:
-    name: "{{ blackbox_exporter_package }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ blackbox_exporter_package }}"
   when:
     - blackbox_exporter_enabled | bool
     - not ansible_check_mode

--- a/ansible/roles/components/caddy/tasks/install.yml
+++ b/ansible/roles/components/caddy/tasks/install.yml
@@ -1,11 +1,11 @@
 ---
 - name: Install Caddy repository prerequisites
-  ansible.builtin.apt:
-    name:
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages:
       - ca-certificates
       - python3-debian
-    state: present
-    update_cache: true
 
 - name: Add Caddy repository
   ansible.builtin.deb822_repository:
@@ -20,9 +20,11 @@
       - main
     signed_by: https://dl.cloudsmith.io/public/caddy/stable/gpg.key
     state: present
+  register: caddy_repository
 
 - name: Install Caddy
-  ansible.builtin.apt:
-    name: caddy
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: caddy
+    daedalus_apt_force_update_cache: "{{ caddy_repository.changed | default(false) }}"

--- a/ansible/roles/components/grafana/tasks/main.yml
+++ b/ansible/roles/components/grafana/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install Grafana repository prerequisites
-  ansible.builtin.apt:
-    name: "{{ grafana_prerequisite_packages }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ grafana_prerequisite_packages }}"
   when:
     - grafana_enabled | bool
     - not ansible_check_mode
@@ -18,15 +18,17 @@
     components: "{{ grafana_repository_components }}"
     signed_by: "{{ grafana_repository_signed_by }}"
     state: present
+  register: grafana_repository
   when:
     - grafana_enabled | bool
     - not ansible_check_mode
 
 - name: Install Grafana
-  ansible.builtin.apt:
-    name: "{{ grafana_package }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ grafana_package }}"
+    daedalus_apt_force_update_cache: "{{ grafana_repository.changed | default(false) }}"
   when:
     - grafana_enabled | bool
     - not ansible_check_mode

--- a/ansible/roles/components/mysql_server/tasks/install.yml
+++ b/ansible/roles/components/mysql_server/tasks/install.yml
@@ -1,8 +1,9 @@
 ---
 - name: Install mysql-server
-  ansible.builtin.apt:
-    name: "{{ mysql_server_packages }}"
-    state: present
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ mysql_server_packages }}"
 
 - name: Start mysql-server
   ansible.builtin.systemd_service:

--- a/ansible/roles/components/prometheus/tasks/main.yml
+++ b/ansible/roles/components/prometheus/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install Prometheus
-  ansible.builtin.apt:
-    name: "{{ prometheus_package }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ prometheus_package }}"
   when:
     - prometheus_enabled | bool
     - not ansible_check_mode

--- a/ansible/roles/dns_authoritative/tasks/main.yml
+++ b/ansible/roles/dns_authoritative/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Install authoritative DNS package
-  ansible.builtin.apt:
-    name: "{{ dns_authoritative_package }}"
-    state: present
-    update_cache: true
-    policy_rc_d: "{{ 101 if dns_authoritative_zones | length == 0 else omit }}"
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ dns_authoritative_package }}"
+    daedalus_apt_policy_rc_d: "{{ 101 if dns_authoritative_zones | length == 0 else omit }}"
   when: dns_authoritative_enabled | bool
 
 - name: Check authoritative DNS config directory

--- a/ansible/roles/dns_recursor/tasks/main.yml
+++ b/ansible/roles/dns_recursor/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install recursive DNS packages
-  ansible.builtin.apt:
-    name: "{{ [dns_recursor_package] + dns_recursor_validation_packages }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ [dns_recursor_package] + dns_recursor_validation_packages }}"
   when: dns_recursor_enabled | bool
 
 - name: Check Unbound configuration directory

--- a/ansible/roles/foundation/platform_lxc/tasks/packages.yml
+++ b/ansible/roles/foundation/platform_lxc/tasks/packages.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install LXC base packages
-  ansible.builtin.apt:
-    name: "{{ foundation_lxc_packages }}"
-    update_cache: true
-    state: present
-  become: "{{ foundation_lxc_become_root }}"
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ foundation_lxc_packages }}"
+    daedalus_apt_become: "{{ foundation_lxc_become_root }}"

--- a/ansible/roles/foundation/platform_lxc/tasks/unattended_upgrades.yml
+++ b/ansible/roles/foundation/platform_lxc/tasks/unattended_upgrades.yml
@@ -1,11 +1,11 @@
 ---
 - name: Install unattended-upgrades
-  ansible.builtin.apt:
-    name:
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages:
       - unattended-upgrades
-    update_cache: true
-    state: present
-  become: "{{ foundation_lxc_become_root }}"
+    daedalus_apt_become: "{{ foundation_lxc_become_root }}"
 
 - name: Copy 20auto-upgrades
   ansible.builtin.copy:

--- a/ansible/roles/foundation/platform_vm/tasks/packages.yml
+++ b/ansible/roles/foundation/platform_vm/tasks/packages.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install VM base packages
-  ansible.builtin.apt:
-    name: "{{ foundation_vm_packages }}"
-    update_cache: true
-    state: present
-  become: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ foundation_vm_packages }}"

--- a/ansible/roles/foundation/platform_vm/tasks/unattended_upgrades.yml
+++ b/ansible/roles/foundation/platform_vm/tasks/unattended_upgrades.yml
@@ -1,11 +1,10 @@
 ---
 - name: Install unattended-upgrades
-  ansible.builtin.apt:
-    name:
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages:
       - unattended-upgrades
-    update_cache: true
-    state: present
-  become: true
 
 - name: Copy 20auto-upgrades
   ansible.builtin.copy:

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install node exporter
-  ansible.builtin.apt:
-    name: "{{ node_exporter_package }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ node_exporter_package }}"
   when:
     - node_exporter_enabled | bool
     - not ansible_check_mode

--- a/ansible/roles/retired_monitoring_cleanup/tasks/main.yml
+++ b/ansible/roles/retired_monitoring_cleanup/tasks/main.yml
@@ -19,11 +19,13 @@
     - retired_monitoring_cleanup_service.status | default('') != 'not-found'
 
 - name: Purge retired monitoring packages
-  ansible.builtin.apt:
-    name: "{{ retired_monitoring_cleanup_packages }}"
-    state: absent
-    purge: true
-    autoremove: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ retired_monitoring_cleanup_packages }}"
+    daedalus_apt_state: absent
+    daedalus_apt_purge: true
+    daedalus_apt_autoremove: true
   when: retired_monitoring_cleanup_enabled | bool
 
 - name: Remove retired monitoring paths

--- a/ansible/roles/services/web/tasks/main.yml
+++ b/ansible/roles/services/web/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install web origin package
-  ansible.builtin.apt:
-    name: "{{ services_web_origin_package }}"
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: "{{ services_web_origin_package }}"
   when: services_web_origin_enabled | bool
 
 - name: Check web origin document root

--- a/ansible/roles/ssh_server/tasks/main.yml
+++ b/ansible/roles/ssh_server/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: Install OpenSSH server
-  ansible.builtin.apt:
-    name: openssh-server
-    state: present
-    update_cache: true
+  ansible.builtin.include_role:
+    name: apt_state
+  vars:
+    daedalus_apt_packages: openssh-server
   when: ssh_server_enabled | bool
 
 - name: Normalize SSH TCP forwarding policy

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,6 +22,12 @@ Use `--playbook cloudflare` deliberately for host-side Cloudflare components;
 it is not part of the default `site` converge because connector hosts require
 operator-provided tunnel tokens for apply runs.
 
+Daedalus does not use Ansible apt tasks for routine package upgrades. Hosts use
+unattended-upgrades for ongoing package updates; Ansible checks requested
+packages with `dpkg-query` and calls apt only when something is missing or a
+cleanup role must purge an installed package. The default apt cache valid time
+is one day, matching the daily unattended-upgrades package-list refresh.
+
 `apply` is the only mutating action and requires `--yes`. Run `check` or `diff`
 first unless there is a clear operational reason not to.
 

--- a/tests/test_apt_state_role.py
+++ b/tests/test_apt_state_role.py
@@ -1,0 +1,73 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_yaml(path: str):
+    return yaml.safe_load((REPO_ROOT / path).read_text(encoding="utf-8"))
+
+
+def iter_tasks(tasks):
+    for task in tasks or []:
+        yield task
+        for key in ("block", "rescue", "always"):
+            if key in task:
+                yield from iter_tasks(task[key])
+
+
+class AptStateRoleTest(unittest.TestCase):
+    def test_apt_defaults_expect_unattended_upgrades_to_keep_cache_fresh(self) -> None:
+        site_vars = load_yaml("ansible/inventories/default/group_vars/default.yml")
+
+        self.assertTrue(site_vars["daedalus_apt_update_cache"])
+        self.assertEqual(site_vars["daedalus_apt_cache_valid_time"], 86400)
+
+    def test_roles_do_not_call_apt_directly(self) -> None:
+        task_files = sorted((REPO_ROOT / "ansible" / "roles").rglob("tasks/*.yml"))
+
+        for path in task_files:
+            if "ansible/roles/apt_state/tasks" in path.as_posix():
+                continue
+
+            with self.subTest(path=path.relative_to(REPO_ROOT).as_posix()):
+                for task in iter_tasks(yaml.safe_load(path.read_text(encoding="utf-8"))):
+                    self.assertNotIn("ansible.builtin.apt", task)
+
+    def test_apt_state_only_invokes_apt_when_dpkg_state_requires_it(self) -> None:
+        tasks = load_yaml("ansible/roles/apt_state/tasks/main.yml")
+        by_name = {task["name"]: task for task in tasks}
+
+        check = by_name["Check requested apt packages"]
+        command = check["ansible.builtin.command"]["argv"]
+        self.assertIn("dpkg-query", command)
+        self.assertEqual(check["changed_when"], False)
+        self.assertEqual(check["failed_when"], False)
+        self.assertEqual(check["check_mode"], False)
+
+        install = by_name["Install missing apt packages"]
+        apt_install = install["ansible.builtin.apt"]
+        self.assertEqual(apt_install["state"], "present")
+        self.assertEqual(
+            apt_install["update_cache"],
+            "{{ daedalus_apt_update_cache | default(true) | bool }}",
+        )
+        self.assertIn(
+            "daedalus_apt_query.rc | default(1) != 0",
+            install["when"],
+        )
+
+        remove = by_name["Remove installed apt packages"]
+        apt_remove = remove["ansible.builtin.apt"]
+        self.assertEqual(apt_remove["state"], "absent")
+        self.assertEqual(
+            "daedalus_apt_query.stdout_lines | default([]) | length > 0",
+            remove["when"][-1],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_caddy_role.py
+++ b/tests/test_caddy_role.py
@@ -29,7 +29,11 @@ class CaddyRoleTest(unittest.TestCase):
 
         prerequisites = by_name["Install Caddy repository prerequisites"]
         self.assertEqual(
-            prerequisites["ansible.builtin.apt"]["name"],
+            prerequisites["ansible.builtin.include_role"]["name"],
+            "apt_state",
+        )
+        self.assertEqual(
+            prerequisites["vars"]["daedalus_apt_packages"],
             ["ca-certificates", "python3-debian"],
         )
 
@@ -44,6 +48,15 @@ class CaddyRoleTest(unittest.TestCase):
         self.assertEqual(
             repository["signed_by"],
             "https://dl.cloudsmith.io/public/caddy/stable/gpg.key",
+        )
+        self.assertEqual(by_name["Add Caddy repository"]["register"], "caddy_repository")
+
+        install = by_name["Install Caddy"]
+        self.assertEqual(install["ansible.builtin.include_role"]["name"], "apt_state")
+        self.assertEqual(install["vars"]["daedalus_apt_packages"], "caddy")
+        self.assertEqual(
+            install["vars"]["daedalus_apt_force_update_cache"],
+            "{{ caddy_repository.changed | default(false) }}",
         )
 
 

--- a/tests/test_foundation_dns_boundaries.py
+++ b/tests/test_foundation_dns_boundaries.py
@@ -191,10 +191,15 @@ class FoundationDnsBoundariesTest(unittest.TestCase):
         self.assertIn("zabbix-release", defaults["retired_monitoring_cleanup_packages"])
         self.assertIn("/etc/zabbix", defaults["retired_monitoring_cleanup_paths"])
 
-        purge = by_name["Purge retired monitoring packages"]["ansible.builtin.apt"]
-        self.assertEqual(purge["state"], "absent")
-        self.assertTrue(purge["purge"])
-        self.assertTrue(purge["autoremove"])
+        purge = by_name["Purge retired monitoring packages"]
+        self.assertEqual(purge["ansible.builtin.include_role"]["name"], "apt_state")
+        self.assertEqual(
+            purge["vars"]["daedalus_apt_packages"],
+            "{{ retired_monitoring_cleanup_packages }}",
+        )
+        self.assertEqual(purge["vars"]["daedalus_apt_state"], "absent")
+        self.assertTrue(purge["vars"]["daedalus_apt_purge"])
+        self.assertTrue(purge["vars"]["daedalus_apt_autoremove"])
 
         stop = by_name["Stop retired monitoring services"]
         self.assertIn(


### PR DESCRIPTION
## Summary

- Add a shared `apt_state` role that checks package state with `dpkg-query` before invoking apt.
- Route package install/purge tasks through `apt_state` so steady-state Ansible runs skip apt when packages are already present.
- Keep forced apt cache refresh only for newly added external repositories, and document the unattended-upgrades boundary.
- Update tests to lock the new package-management contract.

## Why

Unattended-upgrades already handles routine package updates. Re-running apt from Ansible during normal converges made runs heavier than necessary, especially when every role refreshed apt metadata independently.

## Validation

- `python -m pytest -q`
- `ansible-playbook --syntax-check playbooks/site.yml`
- `ansible-playbook --syntax-check playbooks/bootstrap.yml`
- `ansible-playbook --syntax-check playbooks/cloudflare.yml`
- localhost check-mode exercise of `apt_state` with installed packages, confirming apt tasks were skipped

Note: syntax checks emitted a local pyenv shim warning, but all playbook checks completed successfully.