### PR TITLE
[codex] Refactor infra CLI Fire wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,69 +131,97 @@ rebuild the active Atlas runtime there by default.
 Basic shape:
 
 ```bash
-infra <action> [options]
-atlas run infra <action> [options]
+infra <command> [options]
+atlas run infra <command> [options]
 ```
+
+`infra` is a thin Ansible wrapper. It exposes Ansible's site, playbook, limit,
+tags, skip-tags, and extra-vars concepts directly instead of adding
+domain-specific commands. The CLI uses Fire, so examples use the natural long
+option names from the `Infra` method signatures.
 
 Discovery:
 
 ```bash
 infra sites
 infra playbooks
+infra inventory
 infra inventory --site default
 ```
 
-`infra playbooks` only lists the public lifecycle entrypoints:
+`infra playbooks` lists the public playbooks:
 
 - `site`: default steady-state converge
 - `bootstrap`: first converge for a newly added Atlas-managed host
+- `cloudflare`: explicit host-side Cloudflare component run
 
-Focused component playbooks can still be requested explicitly with
-`--playbook` when a top-level playbook exists. `cloudflare` is available as an
-explicit host-side component playbook, but it is not imported into the normal
-`site` converge because apply runs require operator-provided tunnel tokens.
+Focused component playbooks are requested explicitly with `--playbook` when a
+top-level playbook exists. `cloudflare` is not imported into the normal `site`
+converge because apply runs require operator-provided tunnel tokens.
 
 Reachability:
 
 ```bash
 infra ping
-infra ping --site default --limit dns-recursive01
+infra ping --limit dns-recursive01
+infra ping --limit svc_dns_recursive
 ```
 
 Dry-run validation:
 
 ```bash
 infra check
-infra check --site default --limit cap_control_node
-infra check --site default --limit svc_dns_recursive
+infra check --limit svc_dns_recursive
+infra check --playbook cloudflare --limit connector01
+infra check --tags dns --limit dns-recursive01
 ```
 
 Diff preview:
 
 ```bash
 infra diff
-infra diff --site default --limit cap_control_node
-infra diff --site default --limit svc_dns_recursive
+infra diff --limit svc_dns_recursive
+infra diff --playbook cloudflare --limit connector01
 ```
 
 Apply is the mutating action and requires explicit confirmation:
 
 ```bash
 infra apply --yes
-infra apply --yes --site default --limit svc_dns_recursive
+infra apply --limit svc_dns_recursive --yes
+infra apply --playbook bootstrap --limit web02 --yes
 ```
 
-`check`, `diff`, and `apply` support these limited Ansible pass-through options:
+`inventory` supports:
 
 ```text
---limit
---tags
---skip-tags
---extra-vars
+--site
 ```
 
-Before invoking Ansible, `infra` prints the exact command it will run. Unknown
-sites and playbooks fail before Ansible starts.
+`ping` supports:
+
+```text
+--site
+--limit
+```
+
+`check`, `diff`, and `apply` support these Ansible pass-through options:
+
+```text
+--site
+--playbook
+--limit
+--tags
+--skip_tags
+--extra_vars
+```
+
+The default site is `default`. The default playbook for `check`, `diff`, and
+`apply` is `site`.
+
+Before invoking Ansible, `infra` prints the exact command it will run to
+stderr. Command output remains on stdout. Unknown sites and playbooks fail
+before Ansible starts.
 
 ## Inventory Model
 
@@ -259,7 +287,7 @@ inventory when it exists:
 With the default inventory selector, the path is
 `~/.config/daedalus/default.yml`.
 Set `DAEDALUS_OPERATOR_VARS=/path/to/vars.yml` to use a different file.
-Explicit `--extra-vars` values are still supported and are passed after the
+Explicit `--extra_vars` values are still supported and are passed after the
 auto-loaded file.
 
 ## Local Development
@@ -313,21 +341,21 @@ playbook, and limit.
 Bootstrap a cloud-init VM with:
 
 ```bash
-infra apply --yes --site default --playbook bootstrap --limit <new-host>
+infra apply --playbook bootstrap --limit <new-host> --yes
 ```
 
 Then run the steady-state converge for that host:
 
 ```bash
-infra apply --yes --site default --limit <new-host>
+infra apply --limit <new-host> --yes
 ```
 
 Bootstrap a root-only LXC with the same playbook, but override the first login
 user for that one run:
 
 ```bash
-infra apply --yes --site default --playbook bootstrap --limit <new-host> \
-  --extra-vars 'ansible_user=root ansible_become=false'
+infra apply --playbook bootstrap --limit <new-host> --yes \
+  --extra_vars 'ansible_user=root ansible_become=false'
 ```
 
 After that first run, use the normal `site` converge with the standard `ops`
@@ -353,7 +381,7 @@ python -m pip install -e .
 infra sites
 infra playbooks
 infra inventory
-infra check --site default --limit svc_dns_recursive
+infra check --limit svc_dns_recursive
 ```
 
 For documentation-only changes, inspect the rendered Markdown and confirm that

--- a/docs/atlas-host.md
+++ b/docs/atlas-host.md
@@ -73,15 +73,15 @@ hosts: later runs can switch to `ansible_user: ops` with `become: true`.
 For a brand-new VM that already has `ops`, use the shared bootstrap playbook:
 
 ```bash
-infra apply --yes --site default --playbook bootstrap --limit <new-host>
+infra apply --playbook bootstrap --limit <new-host> --yes
 ```
 
 For a brand-new root-only LXC, use the same bootstrap playbook and override the
 first login user for that run:
 
 ```bash
-infra apply --yes --site default --playbook bootstrap --limit <new-host> \
-  --extra-vars 'ansible_user=root ansible_become=false'
+infra apply --playbook bootstrap --limit <new-host> --yes \
+  --extra_vars 'ansible_user=root ansible_become=false'
 ```
 
 The playbook branches inside `foundation/bootstrap`: VM and LXC hosts share one
@@ -172,14 +172,14 @@ atlas_registries:
 Use the wrapper through Atlas on the control node:
 
 ```bash
-atlas run infra inventory --site default
-atlas run infra check --site default --limit cap_control_node
-atlas run infra diff --site default --limit cap_control_node
+atlas run infra inventory
+atlas run infra check --limit cap_control_node
+atlas run infra diff --limit cap_control_node
 ```
 
 For DNS LXC reachability and the service-scoped converge path:
 
 ```bash
-atlas run infra ping --site default --limit dns-recursive01
-atlas run infra check --site default --limit svc_dns_recursive
+atlas run infra ping --limit dns-recursive01
+atlas run infra check --limit svc_dns_recursive
 ```

--- a/docs/bootstrap-control-node.md
+++ b/docs/bootstrap-control-node.md
@@ -14,9 +14,9 @@ itself before it can run.
 `control01` runs operator-triggered commands such as:
 
 ```bash
-atlas run infra inventory --site default
-atlas run infra ping --site default --limit dns-recursive01
-atlas run infra check --site default --limit cap_control_node
+atlas run infra inventory
+atlas run infra ping --limit dns-recursive01
+atlas run infra check --limit cap_control_node
 ```
 
 Daedalus may validate this host and manage non-dangerous configuration on it,
@@ -75,11 +75,11 @@ atlas status
 atlas runtime status
 atlas scripts list --verbose
 ansible-inventory --version
-atlas run infra inventory --site default
-atlas run infra ping --site default --limit dns-recursive01
-atlas run infra check --site default --limit svc_dns_recursive
-atlas run infra check --site default --limit cap_control_node
-atlas run infra diff --site default --limit cap_control_node
+atlas run infra inventory
+atlas run infra ping --limit dns-recursive01
+atlas run infra check --limit svc_dns_recursive
+atlas run infra check --limit cap_control_node
+atlas run infra diff --limit cap_control_node
 ```
 
 The first control node should be assigned to these inventory groups:

--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -79,8 +79,8 @@ work.
 Focused checks from the control node:
 
 ```bash
-atlas run infra check --site default --playbook cloudflare --limit connector01
-atlas run infra check --site default --playbook cloudflare --limit bastion01
+atlas run infra check --playbook cloudflare --limit connector01
+atlas run infra check --playbook cloudflare --limit bastion01
 ```
 
 After apply, validate local host-side state:

--- a/docs/components.md
+++ b/docs/components.md
@@ -9,7 +9,7 @@ component flags. Roles implement host-side state only.
 The steady-state entrypoint is:
 
 ```bash
-atlas run infra check --site default
+atlas run infra check
 ```
 
 Focused runs use the normal `site` playbook plus `--limit`. `cloudflare` is the
@@ -17,9 +17,9 @@ only explicit host-side component playbook outside normal `site` because apply
 runs require operator-provided tunnel tokens:
 
 ```bash
-atlas run infra check --site default --limit svc_dns_recursive
-atlas run infra check --site default --limit cap_control_node
-atlas run infra check --site default --playbook cloudflare
+atlas run infra check --limit svc_dns_recursive
+atlas run infra check --limit cap_control_node
+atlas run infra check --playbook cloudflare
 ```
 
 `cloudflare` is intentionally explicit and is not imported into `site.yml`.
@@ -53,7 +53,7 @@ those values into docs. Use the inventory graph and host/group vars when current
 state is needed:
 
 ```bash
-infra inventory --site default
+infra inventory
 ```
 
 The docs describe role boundaries and operating contracts. Host additions,
@@ -117,18 +117,18 @@ Daedalus component after the host-side state is stable.
 On the control node, use:
 
 ```bash
-atlas run infra inventory --site default
-atlas run infra check --site default --limit dns-recursive01
-atlas run infra check --site default --playbook cloudflare --limit connector01
-atlas run infra check --site default --playbook cloudflare --limit bastion01
-atlas run infra check --site default --limit control01
-atlas run infra ping --site default --limit monitor01
-atlas run infra check --site default --playbook bootstrap --limit monitor01
-atlas run infra check --site default --limit svc_monitoring
-atlas run infra check --site default --limit svc_mysql
-atlas run infra ping --site default --limit web01
-atlas run infra check --site default --limit web01
-atlas run infra check --site default --playbook cloudflare --limit web01
+atlas run infra inventory
+atlas run infra check --limit dns-recursive01
+atlas run infra check --playbook cloudflare --limit connector01
+atlas run infra check --playbook cloudflare --limit bastion01
+atlas run infra check --limit control01
+atlas run infra ping --limit monitor01
+atlas run infra check --playbook bootstrap --limit monitor01
+atlas run infra check --limit svc_monitoring
+atlas run infra check --limit svc_mysql
+atlas run infra ping --limit web01
+atlas run infra check --limit web01
+atlas run infra check --playbook cloudflare --limit web01
 ```
 
 Local development machines may lack Atlas runtime, operator secret material, or

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -87,10 +87,10 @@ for converging DNS desired state.
 From the control node:
 
 ```bash
-infra check --site default --limit svc_dns_recursive
-infra diff --site default --limit svc_dns_recursive
-infra check --site default --limit svc_dns_authoritative
-infra diff --site default --limit svc_dns_authoritative
+infra check --limit svc_dns_recursive
+infra diff --limit svc_dns_recursive
+infra check --limit svc_dns_authoritative
+infra diff --limit svc_dns_authoritative
 ```
 
 On a recursive DNS host:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,8 +4,8 @@ Use Atlas or the generated `infra` shim for production runs:
 
 ```bash
 atlas run infra check
-atlas run infra diff --site default --limit cap_control_node
-atlas run infra apply --yes --site default --limit svc_dns_recursive
+atlas run infra diff --limit cap_control_node
+atlas run infra apply --limit svc_dns_recursive --yes
 ```
 
 Use `infra sites` and `infra playbooks` before targeting a non-default
@@ -39,7 +39,7 @@ for the selected inventory from:
 ```
 
 Set `DAEDALUS_OPERATOR_VARS=/path/to/vars.yml` when an operator run needs a
-different file. Explicit `--extra-vars` still works and is applied after the
+different file. Explicit `--extra_vars` still works and is applied after the
 auto-loaded file.
 
 The monitoring stack does not need operator-provided secrets for the initial
@@ -47,8 +47,8 @@ Prometheus, Grafana, Alertmanager, and blackbox exporter converge. Target it as
 a normal service group:
 
 ```bash
-atlas run infra check --site default --limit svc_monitoring
-atlas run infra apply --yes --site default --limit svc_monitoring
+atlas run infra check --limit svc_monitoring
+atlas run infra apply --limit svc_monitoring --yes
 ```
 
 Prometheus reads file-based service discovery targets prepared under

--- a/modules/daedalus/ansible.py
+++ b/modules/daedalus/ansible.py
@@ -80,16 +80,21 @@ class AnsibleRunner:
         self._run(cmd)
 
     def _run(self, cmd: list[str], ensure_collections: bool = False) -> None:
-        env = os.environ.copy()
-        env["ANSIBLE_CONFIG"] = str(ansible_config_path())
-        executable_dir = str(Path(sys.executable).parent)
-        env["PATH"] = os.pathsep.join([executable_dir, env.get("PATH", "")])
+        env = self._ansible_env()
 
         if ensure_collections:
             self._ensure_collections(env)
 
-        print(f"Running: {shlex.join(cmd)}", flush=True)
+        self._print_command(cmd)
         subprocess.run(cmd, check=True, cwd=self.ansible_root, env=env)
+
+    @staticmethod
+    def _ansible_env() -> dict[str, str]:
+        env = os.environ.copy()
+        env["ANSIBLE_CONFIG"] = str(ansible_config_path())
+        executable_dir = str(Path(sys.executable).parent)
+        env["PATH"] = os.pathsep.join([executable_dir, env.get("PATH", "")])
+        return env
 
     def _relative(self, path: Path) -> str:
         return str(path.relative_to(self.ansible_root))
@@ -141,7 +146,7 @@ class AnsibleRunner:
             "-p",
             self._relative(self._collections_path()),
         ]
-        print(f"Running: {shlex.join(cmd)}", flush=True)
+        self._print_command(cmd)
         try:
             subprocess.run(
                 cmd,
@@ -155,6 +160,10 @@ class AnsibleRunner:
                 "Timed out installing Ansible collections from "
                 f"{self._relative(requirements)}"
             ) from exc
+
+    @staticmethod
+    def _print_command(cmd: list[str]) -> None:
+        print(f"Running: {shlex.join(cmd)}", file=sys.stderr, flush=True)
 
     def _missing_collections(self) -> list[str]:
         return [

--- a/modules/daedalus/cli.py
+++ b/modules/daedalus/cli.py
@@ -1,4 +1,5 @@
 import subprocess
+from collections.abc import Callable
 
 import fire
 
@@ -7,6 +8,15 @@ from .paths import DEFAULT_PLAYBOOK, DEFAULT_SITE, public_playbooks, sites
 
 
 class Infra:
+    def sites(self) -> None:
+        self._print_lines(sites())
+
+    def playbooks(self) -> None:
+        self._print_lines(public_playbooks())
+
+    def inventory(self, site: str = DEFAULT_SITE) -> None:
+        self._run(lambda: AnsibleRunner(site=site).inventory_graph())
+
     def ping(self, site: str = DEFAULT_SITE, limit: str | None = None) -> None:
         self._run(lambda: AnsibleRunner(site=site).adhoc(module="ping", limit=limit))
 
@@ -19,16 +29,15 @@ class Infra:
         skip_tags: str | None = None,
         extra_vars: str | None = None,
     ) -> None:
-        self._run(
-            lambda: AnsibleRunner(site=site).playbook(
-                playbook=playbook,
-                limit=limit,
-                tags=tags,
-                skip_tags=skip_tags,
-                extra_vars=extra_vars,
-                check=True,
-                diff=False,
-            )
+        self._playbook(
+            site=site,
+            playbook=playbook,
+            limit=limit,
+            tags=tags,
+            skip_tags=skip_tags,
+            extra_vars=extra_vars,
+            check=True,
+            diff=False,
         )
 
     def diff(
@@ -40,16 +49,15 @@ class Infra:
         skip_tags: str | None = None,
         extra_vars: str | None = None,
     ) -> None:
-        self._run(
-            lambda: AnsibleRunner(site=site).playbook(
-                playbook=playbook,
-                limit=limit,
-                tags=tags,
-                skip_tags=skip_tags,
-                extra_vars=extra_vars,
-                check=True,
-                diff=True,
-            )
+        self._playbook(
+            site=site,
+            playbook=playbook,
+            limit=limit,
+            tags=tags,
+            skip_tags=skip_tags,
+            extra_vars=extra_vars,
+            check=True,
+            diff=True,
         )
 
     def apply(
@@ -65,6 +73,29 @@ class Infra:
         if not yes:
             raise SystemExit("Error: apply requires --yes")
 
+        self._playbook(
+            site=site,
+            playbook=playbook,
+            limit=limit,
+            tags=tags,
+            skip_tags=skip_tags,
+            extra_vars=extra_vars,
+            check=False,
+            diff=False,
+        )
+
+    def _playbook(
+        self,
+        *,
+        site: str,
+        playbook: str,
+        limit: str | None,
+        tags: str | None,
+        skip_tags: str | None,
+        extra_vars: str | None,
+        check: bool,
+        diff: bool,
+    ) -> None:
         self._run(
             lambda: AnsibleRunner(site=site).playbook(
                 playbook=playbook,
@@ -72,24 +103,18 @@ class Infra:
                 tags=tags,
                 skip_tags=skip_tags,
                 extra_vars=extra_vars,
-                check=False,
-                diff=False,
+                check=check,
+                diff=diff,
             )
         )
 
-    def inventory(self, site: str = DEFAULT_SITE) -> None:
-        self._run(lambda: AnsibleRunner(site=site).inventory_graph())
-
-    def sites(self) -> None:
-        for site in sites():
-            print(site)
-
-    def playbooks(self) -> None:
-        for playbook in public_playbooks():
-            print(playbook)
+    @staticmethod
+    def _print_lines(values: list[str]) -> None:
+        for value in values:
+            print(value)
 
     @staticmethod
-    def _run(action) -> None:
+    def _run(action: Callable[[], None]) -> None:
         try:
             action()
         except RuntimeError as exc:

--- a/tests/test_ansible_runner.py
+++ b/tests/test_ansible_runner.py
@@ -2,13 +2,12 @@ import os
 import subprocess
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
 from daedalus.ansible import AnsibleRunner, CollectionRequirement
-from daedalus.cli import Infra
 
 
 class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
@@ -94,6 +93,99 @@ class AnsibleRunnerOperatorVarsTest(unittest.TestCase):
                 f"Operator vars file not found: {missing_path}",
             ):
                 AnsibleRunner("default").playbook("site")
+
+
+class AnsibleRunnerCommandTest(unittest.TestCase):
+    def capture_playbook_cmd(self, **kwargs) -> list[str]:
+        captured: dict[str, list[str]] = {}
+        runner = AnsibleRunner("default")
+
+        def fake_run(cmd: list[str], ensure_collections: bool = False) -> None:
+            captured["cmd"] = cmd
+
+        runner._run = fake_run  # type: ignore[method-assign]
+        with tempfile.TemporaryDirectory() as home:
+            with patch.dict(os.environ, {"HOME": home}, clear=True):
+                runner.playbook(**kwargs)
+        return captured["cmd"]
+
+    def test_check_command_passes_limit_and_check_to_ansible_playbook(self) -> None:
+        cmd = self.capture_playbook_cmd(
+            playbook="site",
+            limit="svc_dns_recursive",
+            check=True,
+            diff=False,
+        )
+
+        self.assertEqual(
+            cmd,
+            [
+                "ansible-playbook",
+                "-i",
+                "inventories/default/hosts.yml",
+                "playbooks/site.yml",
+                "--limit",
+                "svc_dns_recursive",
+                "--check",
+            ],
+        )
+
+    def test_diff_command_passes_limit_check_and_diff_to_ansible_playbook(self) -> None:
+        cmd = self.capture_playbook_cmd(
+            playbook="site",
+            limit="svc_dns_recursive",
+            check=True,
+            diff=True,
+        )
+
+        self.assertEqual(
+            cmd,
+            [
+                "ansible-playbook",
+                "-i",
+                "inventories/default/hosts.yml",
+                "playbooks/site.yml",
+                "--limit",
+                "svc_dns_recursive",
+                "--check",
+                "--diff",
+            ],
+        )
+
+    def test_apply_bootstrap_command_uses_bootstrap_playbook_with_limit(self) -> None:
+        cmd = self.capture_playbook_cmd(
+            playbook="bootstrap",
+            limit="web02",
+            check=False,
+            diff=False,
+        )
+
+        self.assertEqual(
+            cmd,
+            [
+                "ansible-playbook",
+                "-i",
+                "inventories/default/hosts.yml",
+                "playbooks/bootstrap.yml",
+                "--limit",
+                "web02",
+            ],
+        )
+
+    def test_run_prints_running_line_to_stderr(self) -> None:
+        stdout = StringIO()
+        stderr = StringIO()
+        runner = AnsibleRunner("default")
+
+        with (
+            patch("daedalus.ansible.subprocess.run"),
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+        ):
+            runner._run(["ansible", "all", "-m", "ping"])
+
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Running: ansible all -m ping\n", stderr.getvalue())
 
 
 class AnsibleRunnerCollectionsTest(unittest.TestCase):
@@ -292,19 +384,6 @@ class AnsibleRunnerCollectionRequirementTest(unittest.TestCase):
 
     def test_version_requirement_rejects_unknown_operators(self) -> None:
         self.assertFalse(AnsibleRunner._version_satisfies("5.0.1", "~=5.0"))
-
-
-class InfraPlaybooksTest(unittest.TestCase):
-    def test_playbooks_lists_public_entrypoints(self) -> None:
-        output = StringIO()
-
-        with redirect_stdout(output):
-            Infra().playbooks()
-
-        self.assertEqual(
-            output.getvalue().splitlines(),
-            ["site", "bootstrap", "cloudflare"],
-        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,270 @@
+import inspect
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from unittest.mock import patch
+
+from daedalus.cli import Infra, main
+
+
+class InfraCliSurfaceTest(unittest.TestCase):
+    def test_public_methods_are_the_command_surface(self) -> None:
+        public_methods = sorted(
+            name
+            for name, method in inspect.getmembers(Infra, predicate=inspect.isfunction)
+            if not name.startswith("_")
+        )
+
+        self.assertEqual(
+            public_methods,
+            [
+                "apply",
+                "check",
+                "diff",
+                "inventory",
+                "ping",
+                "playbooks",
+                "sites",
+            ],
+        )
+
+    def test_main_exposes_infra_through_fire(self) -> None:
+        with patch("daedalus.cli.fire.Fire") as fire:
+            main()
+
+        fire.assert_called_once_with(Infra)
+
+
+class InfraCliDiscoveryTest(unittest.TestCase):
+    def test_sites_lists_site_names_only(self) -> None:
+        output = StringIO()
+
+        with redirect_stdout(output):
+            Infra().sites()
+
+        self.assertEqual(output.getvalue().splitlines(), ["default"])
+
+    def test_playbooks_lists_public_playbook_names_only(self) -> None:
+        output = StringIO()
+
+        with redirect_stdout(output):
+            Infra().playbooks()
+
+        self.assertEqual(
+            output.getvalue().splitlines(),
+            ["site", "bootstrap", "cloudflare"],
+        )
+
+
+class InfraCliDispatchTest(unittest.TestCase):
+    def test_inventory_runs_ansible_inventory_graph(self) -> None:
+        with patch("daedalus.cli.AnsibleRunner") as runner_class:
+            Infra().inventory(site="default")
+
+        runner_class.assert_called_once_with(site="default")
+        runner_class.return_value.inventory_graph.assert_called_once_with()
+
+    def test_ping_runs_ansible_ping_with_limit(self) -> None:
+        with patch("daedalus.cli.AnsibleRunner") as runner_class:
+            Infra().ping(limit="dns-recursive01")
+
+        runner_class.assert_called_once_with(site="default")
+        runner_class.return_value.adhoc.assert_called_once_with(
+            module="ping",
+            limit="dns-recursive01",
+        )
+
+    def test_check_runs_playbook_check_with_limit(self) -> None:
+        with patch("daedalus.cli.AnsibleRunner") as runner_class:
+            Infra().check(limit="svc_dns_recursive")
+
+        runner_class.assert_called_once_with(site="default")
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="site",
+            limit="svc_dns_recursive",
+            tags=None,
+            skip_tags=None,
+            extra_vars=None,
+            check=True,
+            diff=False,
+        )
+
+    def test_diff_runs_playbook_check_diff_with_limit(self) -> None:
+        with patch("daedalus.cli.AnsibleRunner") as runner_class:
+            Infra().diff(limit="svc_dns_recursive")
+
+        runner_class.assert_called_once_with(site="default")
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="site",
+            limit="svc_dns_recursive",
+            tags=None,
+            skip_tags=None,
+            extra_vars=None,
+            check=True,
+            diff=True,
+        )
+
+    def test_apply_without_yes_is_nonzero_and_does_not_run(self) -> None:
+        with (
+            patch("daedalus.cli.AnsibleRunner") as runner_class,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            Infra().apply(limit="svc_dns_recursive")
+
+        self.assertEqual(str(raised.exception), "Error: apply requires --yes")
+        runner_class.assert_not_called()
+
+    def test_apply_with_yes_runs_playbook_without_check_or_diff(self) -> None:
+        with patch("daedalus.cli.AnsibleRunner") as runner_class:
+            Infra().apply(limit="svc_dns_recursive", yes=True)
+
+        runner_class.assert_called_once_with(site="default")
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="site",
+            limit="svc_dns_recursive",
+            tags=None,
+            skip_tags=None,
+            extra_vars=None,
+            check=False,
+            diff=False,
+        )
+
+    def test_apply_can_run_bootstrap_playbook_with_limit(self) -> None:
+        with patch("daedalus.cli.AnsibleRunner") as runner_class:
+            Infra().apply(playbook="bootstrap", limit="web02", yes=True)
+
+        runner_class.assert_called_once_with(site="default")
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="bootstrap",
+            limit="web02",
+            tags=None,
+            skip_tags=None,
+            extra_vars=None,
+            check=False,
+            diff=False,
+        )
+
+    def test_runtime_errors_become_system_exit(self) -> None:
+        with (
+            patch(
+                "daedalus.cli.AnsibleRunner",
+                side_effect=RuntimeError("Unknown site 'missing'"),
+            ),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            Infra().inventory(site="missing")
+
+        self.assertEqual(str(raised.exception), "Error: Unknown site 'missing'")
+
+    def test_subprocess_failures_become_system_exit(self) -> None:
+        with (
+            patch("daedalus.cli.AnsibleRunner") as runner_class,
+            self.assertRaises(SystemExit) as raised,
+        ):
+            runner_class.return_value.playbook.side_effect = (
+                subprocess.CalledProcessError(returncode=4, cmd=["ansible-playbook"])
+            )
+            Infra().check()
+
+        self.assertEqual(str(raised.exception), "Error: command failed with exit code 4")
+
+
+class InfraFireDispatchTest(unittest.TestCase):
+    def test_fire_check_command_parses_limit(self) -> None:
+        with (
+            patch.object(sys, "argv", ["infra", "check", "--limit", "svc_dns_recursive"]),
+            patch("daedalus.cli.AnsibleRunner") as runner_class,
+        ):
+            main()
+
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="site",
+            limit="svc_dns_recursive",
+            tags=None,
+            skip_tags=None,
+            extra_vars=None,
+            check=True,
+            diff=False,
+        )
+
+    def test_fire_diff_command_parses_limit(self) -> None:
+        with (
+            patch.object(sys, "argv", ["infra", "diff", "--limit", "svc_dns_recursive"]),
+            patch("daedalus.cli.AnsibleRunner") as runner_class,
+        ):
+            main()
+
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="site",
+            limit="svc_dns_recursive",
+            tags=None,
+            skip_tags=None,
+            extra_vars=None,
+            check=True,
+            diff=True,
+        )
+
+    def test_fire_apply_command_parses_playbook_limit_and_yes(self) -> None:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "infra",
+                    "apply",
+                    "--playbook",
+                    "bootstrap",
+                    "--limit",
+                    "web02",
+                    "--yes",
+                ],
+            ),
+            patch("daedalus.cli.AnsibleRunner") as runner_class,
+        ):
+            main()
+
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="bootstrap",
+            limit="web02",
+            tags=None,
+            skip_tags=None,
+            extra_vars=None,
+            check=False,
+            diff=False,
+        )
+
+    def test_fire_check_command_parses_skip_tags_and_extra_vars(self) -> None:
+        with (
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "infra",
+                    "check",
+                    "--limit",
+                    "svc_dns_recursive",
+                    "--skip_tags",
+                    "bootstrap",
+                    "--extra_vars",
+                    "foo=bar",
+                ],
+            ),
+            patch("daedalus.cli.AnsibleRunner") as runner_class,
+        ):
+            main()
+
+        runner_class.return_value.playbook.assert_called_once_with(
+            playbook="site",
+            limit="svc_dns_recursive",
+            tags=None,
+            skip_tags="bootstrap",
+            extra_vars="foo=bar",
+            check=True,
+            diff=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Kept the `infra` CLI on Fire while tightening the public command surface to the seven supported commands.
- Refactored repeated playbook dispatch in `Infra` behind private helpers so the public methods stay thin and predictable.
- Centralized Ansible environment setup and `Running: ...` command display, with command display emitted to stderr.
- Updated README examples to use Fire-native long option names and added CLI/runner tests for command parsing, command construction, and stdout/stderr behavior.

## Why

The CLI should behave as a small UNIX-style wrapper around Ansible: explicit inputs, plain stdout for useful command output, and no extra domain command layer.

## Validation

- `python -m pytest -q` -> `63 passed`
- `python commands/infra.py apply --limit svc_dns_recursive` exits non-zero without `--yes`